### PR TITLE
Add temporary build files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ local.properties
 
 # STS (Spring Tool Suite)
 .springBeans
+
+# Build tmp files
+*.o
+*.d


### PR DESCRIPTION
Trywialny patch dla dla gitignore. Sluzy przede wszystkim weryfikacji, ze wszystkie ustawienia/klucze/sciezki sa poprawne.