### PR TITLE
Include stdio.h to prevent warning in devcfg.c

### DIFF
--- a/supla-dev/src/devcfg.c
+++ b/supla-dev/src/devcfg.c
@@ -16,6 +16,7 @@
  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  */
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 


### PR DESCRIPTION
```
../src/devcfg.c: In function ‘devcfg_getdev_authkey’:
../src/devcfg.c:178:3: warning: implicit declaration of function ‘snprintf’ [-Wimplicit-function-declaration]
   snprintf(authkey_file, len, "%s.authkey", guid_file);
   ^
../src/devcfg.c:178:3: warning: incompatible implicit declaration of built-in function ‘snprintf’
../src/devcfg.c:178:3: note: include ‘<stdio.h>’ or provide a declaration of ‘snprintf’
```