### PR TITLE
Add thermal protection device configuration

### DIFF
--- a/supla-common/proto.h
+++ b/supla-common/proto.h
@@ -649,6 +649,8 @@ extern char sproto_tag[SUPLA_TAG_SIZE];
 #define SUPLA_DEVICE_CONFIG_FIELD_MODBUS (1ULL << 9)  // v. >= 27
 // type: TDeviceConfig_FirmwareUpdate
 #define SUPLA_DEVICE_CONFIG_FIELD_FIRMWARE_UPDATE (1ULL << 10)  // v. >= 28
+// type: TDeviceConfig_ThermalProtection
+#define SUPLA_DEVICE_CONFIG_FIELD_THERMAL_PROTECTION (1ULL << 11)  // v. >= 29
 
 // BIT map definition for TDS_SuplaDeviceChannel_C::Flags (32 bit)
 // BIT map definition for TDS_SuplaDeviceChannel_D::Flags (64 bit)
@@ -3087,6 +3089,17 @@ typedef struct {
   unsigned char Policy;  // SUPLA_FIRMWARE_UPDATE_POLICY_
   unsigned char Reserved[20];
 } TDeviceConfig_FirmwareUpdate;
+
+typedef struct {
+  _supla_int16_t Threshold;     // 0.1°C
+  _supla_int16_t MinThreshold;  // 0.1°C, readonly
+  _supla_int16_t MaxThreshold;  // 0.1°C, readonly
+
+  unsigned char Enabled;         // 0 - disabled, 1 - enabled
+  unsigned char DisableAllowed;  // readonly
+
+  unsigned char Reserved[8];
+} TDeviceConfig_ThermalProtection;  // v. >= 29
 
 /********************************************
  * CHANNEL CONFIG STRUCTURES

--- a/supla-common/proto_check.cpp
+++ b/supla-common/proto_check.cpp
@@ -236,6 +236,9 @@ static_assert(sizeof(TDeviceConfig_HomeScreenOffDelay) <=
               (unsigned int)SUPLA_DEVICE_CONFIG_MAXSIZE);
 static_assert(sizeof(TDeviceConfig_HomeScreenContent) <=
               (unsigned int)SUPLA_DEVICE_CONFIG_MAXSIZE);
+static_assert((unsigned int)16 == sizeof(TDeviceConfig_ThermalProtection));
+static_assert(sizeof(TDeviceConfig_ThermalProtection) <=
+              (unsigned int)SUPLA_DEVICE_CONFIG_MAXSIZE);
 static_assert((unsigned int)8 == sizeof(TCalCfg_RollerShutterSettings));
 static_assert(sizeof(TCalCfg_RollerShutterSettings) <=
               (unsigned int)SUPLA_CHANNEL_CONFIG_MAXSIZE);

--- a/supla-server/src/jsonconfig/device/device_json_config.cpp
+++ b/supla-server/src/jsonconfig/device/device_json_config.cpp
@@ -38,7 +38,8 @@ const map<unsigned _supla_int16_t, string> device_json_config::field_map = {
     {SUPLA_DEVICE_CONFIG_FIELD_HOME_SCREEN_OFF_DELAY_TYPE, "offDelayType"},
     {SUPLA_DEVICE_CONFIG_FIELD_POWER_STATUS_LED, "powerStatusLed"},
     {SUPLA_DEVICE_CONFIG_FIELD_MODBUS, "modbus"},
-    {SUPLA_DEVICE_CONFIG_FIELD_FIRMWARE_UPDATE, "firmwareUpdatePolicy"}};
+    {SUPLA_DEVICE_CONFIG_FIELD_FIRMWARE_UPDATE, "firmwareUpdatePolicy"},
+    {SUPLA_DEVICE_CONFIG_FIELD_THERMAL_PROTECTION, "thermalProtection"}};
 
 const map<unsigned _supla_int16_t, string>
     device_json_config::home_screen_content_map = {
@@ -740,6 +741,40 @@ void device_json_config::set_firmware_update_config(
   }
 }
 
+void device_json_config::set_thermal_protection(
+    TDeviceConfig_ThermalProtection *cfg) {
+  if (!cfg) {
+    return;
+  }
+
+  cJSON *user_config = cJSON_CreateObject();
+  if (user_config) {
+    set_item_value(user_config, "threshold", cJSON_Number, true, nullptr,
+                   nullptr, cfg->Threshold);
+    set_item_value(user_config, "enabled",
+                   cfg->Enabled ? cJSON_True : cJSON_False, true, nullptr,
+                   nullptr, 0);
+    set_item_value(get_user_root(),
+                   field_map.at(SUPLA_DEVICE_CONFIG_FIELD_THERMAL_PROTECTION),
+                   cJSON_Object, true, user_config, nullptr, 0);
+  }
+
+  cJSON *properties = cJSON_CreateObject();
+  if (properties) {
+    set_item_value(properties, "minThreshold", cJSON_Number, true, nullptr,
+                   nullptr, cfg->MinThreshold);
+    set_item_value(properties, "maxThreshold", cJSON_Number, true, nullptr,
+                   nullptr, cfg->MaxThreshold);
+    set_item_value(properties, "disableAllowed",
+                   cfg->DisableAllowed ? cJSON_True : cJSON_False, true,
+                   nullptr, nullptr, 0);
+    set_item_value(
+        get_properties_root(),
+        field_map.at(SUPLA_DEVICE_CONFIG_FIELD_THERMAL_PROTECTION),
+        cJSON_Object, true, properties, nullptr, 0);
+  }
+}
+
 cJSON *device_json_config::get_root(bool create, bool user,
                                     unsigned _supla_int64_t field) {
   cJSON *root = user ? get_user_root() : get_properties_root();
@@ -914,6 +949,12 @@ void device_json_config::set_config(TSDS_SetDeviceConfig *config) {
           if (left >= (size = sizeof(TDeviceConfig_FirmwareUpdate))) {
             set_firmware_update_config(
                 static_cast<TDeviceConfig_FirmwareUpdate *>(ptr));
+          }
+          break;
+        case SUPLA_DEVICE_CONFIG_FIELD_THERMAL_PROTECTION:
+          if (left >= (size = sizeof(TDeviceConfig_ThermalProtection))) {
+            set_thermal_protection(
+                static_cast<TDeviceConfig_ThermalProtection *>(ptr));
           }
           break;
       }
@@ -1251,6 +1292,56 @@ bool device_json_config::get_firmware_update_config(
   return false;
 }
 
+bool device_json_config::get_thermal_protection(
+    TDeviceConfig_ThermalProtection *cfg) {
+  if (!cfg) {
+    return false;
+  }
+
+  *cfg = {};
+  bool result = false;
+  double value = 0;
+
+  cJSON *user_config = cJSON_GetObjectItem(
+      get_user_root(),
+      field_map.at(SUPLA_DEVICE_CONFIG_FIELD_THERMAL_PROTECTION).c_str());
+  if (user_config) {
+    if (get_double(user_config, "threshold", &value)) {
+      cfg->Threshold = value;
+      result = true;
+    }
+
+    bool enabled = false;
+    if (get_bool(user_config, "enabled", &enabled)) {
+      cfg->Enabled = enabled ? 1 : 0;
+      result = true;
+    }
+  }
+
+  cJSON *properties = cJSON_GetObjectItem(
+      get_properties_root(),
+      field_map.at(SUPLA_DEVICE_CONFIG_FIELD_THERMAL_PROTECTION).c_str());
+  if (properties) {
+    if (get_double(properties, "minThreshold", &value)) {
+      cfg->MinThreshold = value;
+      result = true;
+    }
+
+    if (get_double(properties, "maxThreshold", &value)) {
+      cfg->MaxThreshold = value;
+      result = true;
+    }
+
+    bool disable_allowed = false;
+    if (get_bool(properties, "disableAllowed", &disable_allowed)) {
+      cfg->DisableAllowed = disable_allowed ? 1 : 0;
+      result = true;
+    }
+  }
+
+  return result;
+}
+
 void device_json_config::get_config(TSDS_SetDeviceConfig *config,
                                     unsigned _supla_int64_t fields,
                                     unsigned _supla_int64_t *fields_left) {
@@ -1342,6 +1433,12 @@ void device_json_config::get_config(TSDS_SetDeviceConfig *config,
                       get_firmware_update_config(
                           static_cast<TDeviceConfig_FirmwareUpdate *>(ptr));
           break;
+        case SUPLA_DEVICE_CONFIG_FIELD_THERMAL_PROTECTION:
+          field_set =
+              left >= (size = sizeof(TDeviceConfig_ThermalProtection)) &&
+              get_thermal_protection(
+                  static_cast<TDeviceConfig_ThermalProtection *>(ptr));
+          break;
       }
 
       if (field_set) {
@@ -1401,6 +1498,17 @@ void device_json_config::leave_only_thise_fields(
     }
   }
 
+  if (!(fields & SUPLA_DEVICE_CONFIG_FIELD_THERMAL_PROTECTION)) {
+    cJSON *root = get_properties_root();
+    cJSON *item = cJSON_GetObjectItem(
+        root,
+        field_map.at(SUPLA_DEVICE_CONFIG_FIELD_THERMAL_PROTECTION).c_str());
+    if (item) {
+      cJSON_DetachItemViaPointer(root, item);
+      cJSON_Delete(item);
+    }
+  }
+
   remove_empty_sub_roots();
 }
 
@@ -1418,6 +1526,17 @@ void device_json_config::remove_fields(unsigned _supla_int64_t fields) {
     }
   }
 
+  if (fields & SUPLA_DEVICE_CONFIG_FIELD_THERMAL_PROTECTION) {
+    cJSON *root = get_properties_root();
+    cJSON *item = cJSON_GetObjectItem(
+        root,
+        field_map.at(SUPLA_DEVICE_CONFIG_FIELD_THERMAL_PROTECTION).c_str());
+    if (item) {
+      cJSON_DetachItemViaPointer(root, item);
+      cJSON_Delete(item);
+    }
+  }
+
   remove_empty_sub_roots();
 }
 
@@ -1426,7 +1545,8 @@ void device_json_config::merge(supla_json_config *_dst) {
 
   map<unsigned _supla_int16_t, string> props_fields = {
       {1, content_available},
-      {2, field_map.at(SUPLA_DEVICE_CONFIG_FIELD_MODBUS)}};
+      {2, field_map.at(SUPLA_DEVICE_CONFIG_FIELD_MODBUS)},
+      {3, field_map.at(SUPLA_DEVICE_CONFIG_FIELD_THERMAL_PROTECTION)}};
 
   map<cJSON *, map<unsigned _supla_int16_t, string>> map;
 

--- a/supla-server/src/jsonconfig/device/device_json_config.h
+++ b/supla-server/src/jsonconfig/device/device_json_config.h
@@ -87,6 +87,7 @@ class device_json_config : public supla_json_config {
   void set_home_screen_content(TDeviceConfig_HomeScreenContent *content);
   void set_modbus_config(TDeviceConfig_Modbus *cfg);
   void set_firmware_update_config(TDeviceConfig_FirmwareUpdate *cfg);
+  void set_thermal_protection(TDeviceConfig_ThermalProtection *cfg);
   void remove_empty_sub_roots();
 
  public:
@@ -115,6 +116,7 @@ class device_json_config : public supla_json_config {
       TDeviceConfig_HomeScreenOffDelayType *type);
   bool get_modbus_config(TDeviceConfig_Modbus *cfg);
   bool get_firmware_update_config(TDeviceConfig_FirmwareUpdate *cfg);
+  bool get_thermal_protection(TDeviceConfig_ThermalProtection *cfg);
 };
 
 #endif /* DEVICE_JSON_CONFIG_H_ */

--- a/supla-server/src/test/jsonconfig/device/DeviceConfigTest.cpp
+++ b/supla-server/src/test/jsonconfig/device/DeviceConfigTest.cpp
@@ -82,6 +82,86 @@ TEST_F(DeviceConfigTest, screenBrightness) {
   free(str);
 }
 
+TEST_F(DeviceConfigTest, thermalProtection) {
+  TSDS_SetDeviceConfig sds_cfg = {};
+  sds_cfg.Fields = SUPLA_DEVICE_CONFIG_FIELD_THERMAL_PROTECTION;
+  sds_cfg.ConfigSize = sizeof(TDeviceConfig_ThermalProtection);
+
+  TDeviceConfig_ThermalProtection *thermal =
+      (TDeviceConfig_ThermalProtection *)sds_cfg.Config;
+  thermal->Threshold = 210;
+  thermal->MinThreshold = 50;
+  thermal->MaxThreshold = 300;
+  thermal->Enabled = 1;
+  thermal->DisableAllowed = 1;
+
+  device_json_config cfg;
+  cfg.set_config(&sds_cfg);
+
+  char *user_config = cfg.get_user_config();
+  ASSERT_TRUE(user_config != nullptr);
+  EXPECT_STREQ(user_config,
+               "{\"thermalProtection\":{\"threshold\":210,\"enabled\":true}}");
+  free(user_config);
+
+  char *properties = cfg.get_properties();
+  ASSERT_TRUE(properties != nullptr);
+  EXPECT_STREQ(
+      properties,
+      "{\"thermalProtection\":{\"minThreshold\":50,\"maxThreshold\":300,"
+      "\"disableAllowed\":true}}");
+  free(properties);
+
+  TSDS_SetDeviceConfig sds_cfg2 = {};
+  cfg.get_config(&sds_cfg2, nullptr);
+
+  ASSERT_EQ(sds_cfg2.Fields, sds_cfg.Fields);
+  ASSERT_EQ(sds_cfg2.ConfigSize, sds_cfg.ConfigSize);
+  EXPECT_EQ(memcmp(sds_cfg2.Config, sds_cfg.Config, sds_cfg.ConfigSize), 0);
+}
+
+TEST_F(DeviceConfigTest, thermalProtectionMergeAndCleanup) {
+  const char user_config[] =
+      "{\"thermalProtection\":{\"threshold\":210,\"enabled\":true}}";
+  const char properties[] =
+      "{\"thermalProtection\":{\"minThreshold\":50,\"maxThreshold\":300,"
+      "\"disableAllowed\":true}}";
+
+  device_json_config incoming;
+  incoming.set_user_config(user_config);
+  incoming.set_properties(properties);
+
+  device_json_config persisted;
+  incoming.merge(&persisted);
+
+  char *str = persisted.get_user_config();
+  ASSERT_NE(str, nullptr);
+  EXPECT_STREQ(str, user_config);
+  free(str);
+
+  str = persisted.get_properties();
+  ASSERT_NE(str, nullptr);
+  EXPECT_STREQ(str, properties);
+  free(str);
+
+  persisted.leave_only_thise_fields(0);
+  str = persisted.get_properties();
+  ASSERT_NE(str, nullptr);
+  EXPECT_STREQ(str, "{}");
+  free(str);
+
+  incoming.remove_fields(SUPLA_DEVICE_CONFIG_FIELD_THERMAL_PROTECTION);
+  str = incoming.get_properties();
+  ASSERT_NE(str, nullptr);
+  EXPECT_STREQ(str, "{}");
+  free(str);
+
+  TSDS_SetDeviceConfig sds_cfg = {};
+  incoming.get_config(&sds_cfg, nullptr);
+  EXPECT_EQ(sds_cfg.Fields, 0);
+  EXPECT_EQ(sds_cfg.ConfigSize, 0);
+}
+
 TEST_F(DeviceConfigTest, allFields) {
   TSDS_SetDeviceConfig sds_cfg = {};
   sds_cfg.Fields = SUPLA_DEVICE_CONFIG_FIELD_STATUS_LED |
@@ -94,7 +174,8 @@ TEST_F(DeviceConfigTest, allFields) {
                    SUPLA_DEVICE_CONFIG_FIELD_HOME_SCREEN_CONTENT |
                    SUPLA_DEVICE_CONFIG_FIELD_HOME_SCREEN_OFF_DELAY_TYPE |
                    SUPLA_DEVICE_CONFIG_FIELD_MODBUS |
-                   SUPLA_DEVICE_CONFIG_FIELD_FIRMWARE_UPDATE;
+                   SUPLA_DEVICE_CONFIG_FIELD_FIRMWARE_UPDATE |
+                   SUPLA_DEVICE_CONFIG_FIELD_THERMAL_PROTECTION;
 
   ((TDeviceConfig_StatusLed *)&sds_cfg.Config[sds_cfg.ConfigSize])
       ->StatusLedType = SUPLA_DEVCFG_STATUS_LED_ALWAYS_OFF;
@@ -167,6 +248,16 @@ TEST_F(DeviceConfigTest, allFields) {
   sds_cfg.ConfigSize += sizeof(TDeviceConfig_FirmwareUpdate);
   ASSERT_LE(sds_cfg.ConfigSize, SUPLA_DEVICE_CONFIG_MAXSIZE);
 
+  TDeviceConfig_ThermalProtection *thermal =
+      (TDeviceConfig_ThermalProtection *)&sds_cfg.Config[sds_cfg.ConfigSize];
+  thermal->Threshold = 210;
+  thermal->MinThreshold = 50;
+  thermal->MaxThreshold = 300;
+  thermal->Enabled = 1;
+  thermal->DisableAllowed = 1;
+  sds_cfg.ConfigSize += sizeof(TDeviceConfig_ThermalProtection);
+  ASSERT_LE(sds_cfg.ConfigSize, SUPLA_DEVICE_CONFIG_MAXSIZE);
+
   device_json_config cfg;
   cfg.set_config(&sds_cfg);
   char *str = cfg.get_user_config();
@@ -180,7 +271,8 @@ TEST_F(DeviceConfigTest, allFields) {
       "\"ENABLED\",\"modbus\":{\"role\":\"SLAVE\",\"modbusAddress\":123,"
       "\"slaveTimeoutMs\":0,\"serialConfig\":{\"mode\":\"RTU\",\"baudRate\":"
       "9600,\"stopBits\":\"ONE\"},\"networkConfig\":{\"mode\":\"TCP\",\"port\":"
-      "88}},\"firmwareUpdatePolicy\":\"ALL_ENABLED\"}");
+      "88}},\"firmwareUpdatePolicy\":\"ALL_ENABLED\",\"thermalProtection\":"
+      "{\"threshold\":210,\"enabled\":true}}");
 
   device_json_config cfg2;
   cfg2.set_user_config(str);
@@ -196,7 +288,9 @@ TEST_F(DeviceConfigTest, allFields) {
       "AUX_TEMPERATURE\",\"MODE_OR_TEMPERATURE\"],\"modbus\":{"
       "\"availableProtocols\":[\"MASTER\",\"SLAVE\",\"RTU\",\"ASCII\",\"TCP\","
       "\"UDP\"],\"availableBaudrates\":[4800,9600,19200,38400,57600,115200],"
-      "\"availableStopbits\":[\"ONE\",\"TWO\",\"ONE_AND_HALF\"]}}");
+      "\"availableStopbits\":[\"ONE\",\"TWO\",\"ONE_AND_HALF\"]},"
+      "\"thermalProtection\":{\"minThreshold\":50,\"maxThreshold\":300,"
+      "\"disableAllowed\":true}}");
 
   cfg2.set_properties(str);
 
@@ -686,7 +780,8 @@ TEST_F(DeviceConfigTest, availableFields) {
       "{\"statusLed\":2,\"screenBrightness\":{\"level\":24},\"buttonVolume\":"
       "100,\"userInterface\":{\"disabled\":false},\"automaticTimeSync\":true,"
       "\"homeScreen\": {\"offDelay\":123,\"content\": "
-      "\"TEMPERATURE_AND_HUMIDITY\"}}");
+      "\"TEMPERATURE_AND_HUMIDITY\"},\"thermalProtection\":{\"threshold\":210,"
+      "\"enabled\":true}}");
 
   EXPECT_EQ(cfg.get_available_fields(),
             SUPLA_DEVICE_CONFIG_FIELD_STATUS_LED |
@@ -695,7 +790,8 @@ TEST_F(DeviceConfigTest, availableFields) {
                 SUPLA_DEVICE_CONFIG_FIELD_DISABLE_USER_INTERFACE |
                 SUPLA_DEVICE_CONFIG_FIELD_AUTOMATIC_TIME_SYNC |
                 SUPLA_DEVICE_CONFIG_FIELD_HOME_SCREEN_OFF_DELAY |
-                SUPLA_DEVICE_CONFIG_FIELD_HOME_SCREEN_CONTENT);
+                SUPLA_DEVICE_CONFIG_FIELD_HOME_SCREEN_CONTENT |
+                SUPLA_DEVICE_CONFIG_FIELD_THERMAL_PROTECTION);
 }
 
 TEST_F(DeviceConfigTest, modbus_1) {


### PR DESCRIPTION
Add protocol definitions and server-side JSON handling for thermal protection settings, including readonly limits and disable capability.

Persist and clean up thermal protection properties correctly, and add coverage for serialization, merge, cleanup, and full config round-trips.
