### PR TITLE
Add InputActivation device configuration support

### DIFF
--- a/supla-common/SqlShell.cpp
+++ b/supla-common/SqlShell.cpp
@@ -1,20 +1,5 @@
-/*
- Copyright (C) AC SOFTWARE SP. Z O.O.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
+// SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "SqlShell.h"
 

--- a/supla-common/SqlShell.h
+++ b/supla-common/SqlShell.h
@@ -1,20 +1,5 @@
-/*
- Copyright (C) AC SOFTWARE SP. Z O.O.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
+// SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 #ifndef SQLSHELL_H_
 #define SQLSHELL_H_

--- a/supla-common/cfg.c
+++ b/supla-common/cfg.c
@@ -1,20 +1,5 @@
-/*
- Copyright (C) AC SOFTWARE SP. Z O.O.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
+// SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 #define _POSIX_C_SOURCE 200809L
 

--- a/supla-common/cfg.h
+++ b/supla-common/cfg.h
@@ -1,20 +1,5 @@
-/*
- Copyright (C) AC SOFTWARE SP. Z O.O.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
+// SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 #ifndef suplacfg_H_
 #define suplacfg_H_

--- a/supla-common/dbcommon.cpp
+++ b/supla-common/dbcommon.cpp
@@ -1,20 +1,5 @@
-/*
- Copyright (C) AC SOFTWARE SP. Z O.O.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
+// SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "dbcommon.h"
 

--- a/supla-common/dbcommon.h
+++ b/supla-common/dbcommon.h
@@ -1,20 +1,5 @@
-/*
- Copyright (C) AC SOFTWARE SP. Z O.O.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
+// SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 #ifndef DBCOMMON_H_
 #define DBCOMMON_H_

--- a/supla-common/eh.c
+++ b/supla-common/eh.c
@@ -1,20 +1,5 @@
-/*
- Copyright (C) AC SOFTWARE SP. Z O.O.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
+// SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 #ifndef ARDUINO
 

--- a/supla-common/eh.h
+++ b/supla-common/eh.h
@@ -1,20 +1,5 @@
-/*
- Copyright (C) AC SOFTWARE SP. Z O.O.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
+// SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
+// SPDX-License-Identifier: GPL-2.0-or-later
 #ifndef EH_H_
 #define EH_H_
 

--- a/supla-common/eh.h
+++ b/supla-common/eh.h
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
 // SPDX-License-Identifier: GPL-2.0-or-later
+
 #ifndef EH_H_
 #define EH_H_
 

--- a/supla-common/helper/inja_sandbox.cpp
+++ b/supla-common/helper/inja_sandbox.cpp
@@ -1,20 +1,5 @@
-/*
- Copyright (C) AC SOFTWARE SP. Z O.O.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
+// SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "inja_sandbox.h"
 

--- a/supla-common/helper/inja_sandbox.h
+++ b/supla-common/helper/inja_sandbox.h
@@ -1,20 +1,5 @@
-/*
- Copyright (C) AC SOFTWARE SP. Z O.O.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
+// SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 #ifndef INJA_SANDBOX_H_
 #define INJA_SANDBOX_H_

--- a/supla-common/helper/json_helper.cpp
+++ b/supla-common/helper/json_helper.cpp
@@ -1,20 +1,5 @@
-/*
- Copyright (C) AC SOFTWARE SP. Z O.O.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
+// SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <ctype.h>
 #include <helper/json_helper.h>

--- a/supla-common/helper/json_helper.h
+++ b/supla-common/helper/json_helper.h
@@ -1,20 +1,5 @@
-/*
- Copyright (C) AC SOFTWARE SP. Z O.O.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
+// SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 #ifndef JSON_HELPER_H_
 #define JSON_HELPER_H_

--- a/supla-common/ini.c
+++ b/supla-common/ini.c
@@ -1,13 +1,12 @@
-/*
-Copyright (c) 2009, Ben Hoyt
+// SPDX-FileCopyrightText: 2009 Ben Hoyt
+// SPDX-License-Identifier: BSD-3-Clause
 
+/*
 inih -- simple .INI file parser
 
-inih is released under the New BSD license (see LICENSE.txt). Go to the project
-home page for more info:
+Go to the project home page for more info:
 
 http://code.google.com/p/inih/
-
 */
 
 #define _POSIX_C_SOURCE 200809L

--- a/supla-common/ini.h
+++ b/supla-common/ini.h
@@ -1,10 +1,10 @@
-/*
-Copyright (c) 2009, Ben Hoyt
+// SPDX-FileCopyrightText: 2009 Ben Hoyt
+// SPDX-License-Identifier: BSD-3-Clause
 
+/*
 inih -- simple .INI file parser
 
-inih is released under the New BSD license (see LICENSE.txt). Go to the project
-home page for more info:
+Go to the project home page for more info:
 
 http://code.google.com/p/inih/
 */

--- a/supla-common/ipcsocket.c
+++ b/supla-common/ipcsocket.c
@@ -1,20 +1,5 @@
-/*
- Copyright (C) AC SOFTWARE SP. Z O.O.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
+// SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 #define _POSIX_C_SOURCE 200809L
 

--- a/supla-common/ipcsocket.h
+++ b/supla-common/ipcsocket.h
@@ -1,20 +1,5 @@
-/*
- Copyright (C) AC SOFTWARE SP. Z O.O.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
+// SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 #ifndef IPCSOCKET_H_
 #define IPCSOCKET_H_

--- a/supla-common/lck.c
+++ b/supla-common/lck.c
@@ -1,20 +1,5 @@
-/*
- Copyright (C) AC SOFTWARE SP. Z O.O.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
+// SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "lck.h"
 

--- a/supla-common/lck.h
+++ b/supla-common/lck.h
@@ -1,20 +1,5 @@
-/*
- Copyright (C) AC SOFTWARE SP. Z O.O.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
+// SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 #ifndef LCK_H_
 #define LCK_H_

--- a/supla-common/log.c
+++ b/supla-common/log.c
@@ -1,20 +1,5 @@
-/*
- Copyright (C) AC SOFTWARE SP. Z O.O.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
+// SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 #define _POSIX_C_SOURCE 200809L
 

--- a/supla-common/log.c
+++ b/supla-common/log.c
@@ -52,6 +52,20 @@ static const char *SUPLA_TAG = "SUPLA";
 #include <android/log.h>
 #endif /*__ANDROID__*/
 
+static int __supla_log_level = LOG_VERBOSE;
+
+void LOG_ICACHE_FLASH supla_log_set_level(int level) {
+  __supla_log_level = level;
+}
+
+int LOG_ICACHE_FLASH supla_log_get_level(void) {
+  return __supla_log_level;
+}
+
+char LOG_ICACHE_FLASH supla_log_is_enabled(int level) {
+  return level <= __supla_log_level;
+}
+
 #ifdef __LOG_CALLBACK
 _supla_log_callback __supla_log_callback = NULL;
 
@@ -122,7 +136,7 @@ void supla_vlog(int __pri, const char *message) {
   serialPrintLn(message);
 }
 #elif defined(ESP_PLATFORM)
-// variant for ESP8266 RTOS and ESP-IDF
+// variant for ESP-IDF
 void supla_vlog(int __pri, const char *message) {
   switch (__pri) {
     case LOG_VERBOSE:
@@ -257,9 +271,10 @@ void LOG_ICACHE_FLASH supla_log(int __pri, const char *__fmt, ...) {
 
 #if defined(ESP8266) || defined(ARDUINO) || defined(_WIN32) || \
     defined(SUPLA_DEVICE)
-  if (__fmt == NULL) return;
+  if (__fmt == NULL || !supla_log_is_enabled(__pri)) return;
 #else
-  if (__fmt == NULL || (debug_mode == 0 && __pri == LOG_DEBUG)) return;
+  if (__fmt == NULL || !supla_log_is_enabled(__pri) ||
+      (debug_mode == 0 && __pri == LOG_DEBUG)) return;
 #endif
 
   while (1) {

--- a/supla-common/log.h
+++ b/supla-common/log.h
@@ -1,20 +1,5 @@
-/*
- Copyright (C) AC SOFTWARE SP. Z O.O.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
+// SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 #ifndef suplalog_H_
 #define suplalog_H_

--- a/supla-common/log.h
+++ b/supla-common/log.h
@@ -47,6 +47,9 @@ typedef int (*_supla_log_callback)(int __pri, const char *message);
 void LOG_ICACHE_FLASH supla_log_set_callback(_supla_log_callback callback);
 #endif /*__LOG_CALLBACK*/
 
+void LOG_ICACHE_FLASH supla_log_set_level(int level);
+int LOG_ICACHE_FLASH supla_log_get_level(void);
+char LOG_ICACHE_FLASH supla_log_is_enabled(int level);
 void LOG_ICACHE_FLASH supla_log(int __pri, const char *__fmt, ...);
 void LOG_ICACHE_FLASH supla_write_state_file(const char *file, int __pri,
                                              const char *__fmt, ...);

--- a/supla-common/proto.c
+++ b/supla-common/proto.c
@@ -1,20 +1,5 @@
-/*
- Copyright (C) AC SOFTWARE SP. Z O.O.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
+// SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 #define _POSIX_C_SOURCE 200809L
 

--- a/supla-common/proto.h
+++ b/supla-common/proto.h
@@ -1,20 +1,5 @@
-/*
- Copyright (C) AC SOFTWARE SP. Z O.O.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
+// SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 #ifndef supla_proto_H_
 #define supla_proto_H_

--- a/supla-common/proto.h
+++ b/supla-common/proto.h
@@ -31,7 +31,7 @@ struct _supla_timeval {
 
 #elif defined(ESP8266) || defined(ESP32) || defined(ESP_PLATFORM)
 // *** Espressif NONOS SDK for ESP8266 OR ARDUINO WITH ESP8266 or ESP32 ***
-// *** ESP-IDF, ESP8266 RTOS SDK ***
+// *** ESP-IDF ***
 #ifndef ESP_PLATFORM
 #ifndef ARDUINO
 #include <mem.h>
@@ -589,6 +589,8 @@ extern char sproto_tag[SUPLA_TAG_SIZE];
 #define SUPLA_MFR_HPD 19
 #define SUPLA_MFR_LUKFUD 20
 #define SUPLA_MFR_WALA 21
+#define SUPLA_MFR_PROVENT 22
+#define SUPLA_MFR_SMARTBOB 23
 
 // BIT map definition for TDS_SuplaRegisterDevice_*::Flags (32 bit)
 #define SUPLA_DEVICE_FLAG_CALCFG_ENTER_CFG_MODE 0x0010          // ver. >= 17

--- a/supla-common/proto.h
+++ b/supla-common/proto.h
@@ -653,8 +653,9 @@ extern char sproto_tag[SUPLA_TAG_SIZE];
 #define SUPLA_DEVICE_CONFIG_FIELD_INPUT_ACTIVATION \
   (1ULL << 12)  // v. >= 30
 
-#define SUPLA_DEVCFG_INPUT_ACTIVATION_GND (1U << 0)
-#define SUPLA_DEVCFG_INPUT_ACTIVATION_VCC (1U << 1)
+#define SUPLA_DEVCFG_INPUT_ACTIVATION_GND        (1U << 0)
+#define SUPLA_DEVCFG_INPUT_ACTIVATION_VCC        (1U << 1)
+#define SUPLA_DEVCFG_INPUT_ACTIVATION_GND_OR_VCC (1U << 2)
 
 // BIT map definition for TDS_SuplaDeviceChannel_C::Flags (32 bit)
 // BIT map definition for TDS_SuplaDeviceChannel_D::Flags (64 bit)

--- a/supla-common/proto.h
+++ b/supla-common/proto.h
@@ -653,7 +653,7 @@ extern char sproto_tag[SUPLA_TAG_SIZE];
 #define SUPLA_DEVICE_CONFIG_FIELD_THERMAL_PROTECTION (1ULL << 11)  // v. >= 29
 // type: TDeviceConfig_InputActivation
 #define SUPLA_DEVICE_CONFIG_FIELD_INPUT_ACTIVATION \
-  (1ULL << 12)  // v. >= 30
+  (1ULL << 12)  // v. >= 29
 
 #define SUPLA_DEVCFG_INPUT_ACTIVATION_GND        (1U << 0)
 #define SUPLA_DEVCFG_INPUT_ACTIVATION_VCC        (1U << 1)

--- a/supla-common/proto.h
+++ b/supla-common/proto.h
@@ -649,6 +649,12 @@ extern char sproto_tag[SUPLA_TAG_SIZE];
 #define SUPLA_DEVICE_CONFIG_FIELD_MODBUS (1ULL << 9)  // v. >= 27
 // type: TDeviceConfig_FirmwareUpdate
 #define SUPLA_DEVICE_CONFIG_FIELD_FIRMWARE_UPDATE (1ULL << 10)  // v. >= 28
+// type: TDeviceConfig_InputActivation
+#define SUPLA_DEVICE_CONFIG_FIELD_INPUT_ACTIVATION \
+  (1ULL << 12)  // v. >= 30
+
+#define SUPLA_DEVCFG_INPUT_ACTIVATION_GND (1U << 0)
+#define SUPLA_DEVCFG_INPUT_ACTIVATION_VCC (1U << 1)
 
 // BIT map definition for TDS_SuplaDeviceChannel_C::Flags (32 bit)
 // BIT map definition for TDS_SuplaDeviceChannel_D::Flags (64 bit)
@@ -3087,6 +3093,18 @@ typedef struct {
   unsigned char Policy;  // SUPLA_FIRMWARE_UPDATE_POLICY_
   unsigned char Reserved[20];
 } TDeviceConfig_FirmwareUpdate;
+
+// type: TDeviceConfig_InputActivation
+typedef struct {
+  // Bitmask of SUPLA_DEVCFG_INPUT_ACTIVATION_* values supported by the device.
+  // Read-only for clients.
+  unsigned char AvailableModes;
+
+  // One selected SUPLA_DEVCFG_INPUT_ACTIVATION_* value.
+  unsigned char Mode;
+
+  unsigned char Reserved[6];
+} TDeviceConfig_InputActivation;
 
 /********************************************
  * CHANNEL CONFIG STRUCTURES

--- a/supla-common/proto_check.cpp
+++ b/supla-common/proto_check.cpp
@@ -1,20 +1,5 @@
-/*
-   Copyright (C) AC SOFTWARE SP. Z O.O
-
-   This program is free software; you can redistribute it and/or
-   modify it under the terms of the GNU General Public License
-   as published by the Free Software Foundation; either version 2
-   of the License, or (at your option) any later version.
-
-   This program is distributed in the hope that it will be useful,
-   but WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-   GNU General Public License for more details.
-
-   You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
-   */
+// SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "proto.h"
 

--- a/supla-common/proto_check.cpp
+++ b/supla-common/proto_check.cpp
@@ -94,9 +94,11 @@ static_assert((unsigned int)62 == sizeof(TElectricityMeter_Measurement));
 // static_assert((unsigned int)429 == sizeof(TElectricityMeter_ExtendedValue));
 
 // deprecated
+#ifdef USE_DEPRECATED_EMEV_V2
 static_assert((139 +
                sizeof(TElectricityMeter_Measurement) * EM_MEASUREMENT_COUNT) ==
               sizeof(TElectricityMeter_ExtendedValue_V2));
+#endif
 
 static_assert((144 +
                sizeof(TElectricityMeter_Measurement) * EM_MEASUREMENT_COUNT) ==
@@ -123,8 +125,10 @@ static_assert(sizeof(TElectricityMeter_Value) <=
 //               (unsigned int)SUPLA_CHANNELEXTENDEDVALUE_SIZE);
 
 // deprecated
+#ifdef USE_DEPRECATED_EMEV_V2
 static_assert(sizeof(TElectricityMeter_ExtendedValue_V2) <=
               (unsigned int)SUPLA_CHANNELEXTENDEDVALUE_SIZE);
+#endif
 static_assert(sizeof(TElectricityMeter_ExtendedValue_V3) <=
               (unsigned int)SUPLA_CHANNELEXTENDEDVALUE_SIZE);
 static_assert((unsigned int)4 == sizeof(TThermostat_Time));

--- a/supla-common/proto_check.cpp
+++ b/supla-common/proto_check.cpp
@@ -236,6 +236,9 @@ static_assert(sizeof(TDeviceConfig_HomeScreenOffDelay) <=
               (unsigned int)SUPLA_DEVICE_CONFIG_MAXSIZE);
 static_assert(sizeof(TDeviceConfig_HomeScreenContent) <=
               (unsigned int)SUPLA_DEVICE_CONFIG_MAXSIZE);
+static_assert(sizeof(TDeviceConfig_InputActivation) == 8);
+static_assert(sizeof(TDeviceConfig_InputActivation) <=
+              (unsigned int)SUPLA_DEVICE_CONFIG_MAXSIZE);
 static_assert((unsigned int)8 == sizeof(TCalCfg_RollerShutterSettings));
 static_assert(sizeof(TCalCfg_RollerShutterSettings) <=
               (unsigned int)SUPLA_CHANNEL_CONFIG_MAXSIZE);

--- a/supla-common/safearray.c
+++ b/supla-common/safearray.c
@@ -1,20 +1,5 @@
-/*
- Copyright (C) AC SOFTWARE SP. Z O.O.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
+// SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "safearray.h"
 

--- a/supla-common/safearray.h
+++ b/supla-common/safearray.h
@@ -1,20 +1,5 @@
-/*
- Copyright (C) AC SOFTWARE SP. Z O.O.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
+// SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 #ifndef SAFEARRAY_H_
 #define SAFEARRAY_H_

--- a/supla-common/srpc.c
+++ b/supla-common/srpc.c
@@ -1,20 +1,5 @@
-/*
- Copyright (C) AC SOFTWARE SP. Z O.O.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
+// SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "srpc.h"
 

--- a/supla-common/srpc.c
+++ b/supla-common/srpc.c
@@ -812,6 +812,16 @@ char SRPC_ICACHE_FLASH srpc_getdata(void *_srpc, TsrpcReceivedData *rd,
     rd->call_id = srpc->sdp.call_id;
     rd->rr_id = srpc->sdp.rr_id;
 
+#ifdef SRPC_WITH_PACKET_LOG_HOOKS
+    if (srpc->params.on_packet_received != NULL) {
+      srpc->params.on_packet_received(_srpc,
+                                      rd->call_id,
+                                      srpc->sdp.data,
+                                      srpc->sdp.data_size,
+                                      srpc->params.user_params);
+    }
+#endif
+
     // first one
     rd->data.dcs_ping = NULL;
 
@@ -1898,6 +1908,15 @@ _supla_int_t SRPC_ICACHE_FLASH srpc_async__call(void *_srpc,
   if (SUPLA_RESULT_TRUE ==
           sproto_set_data(&srpc->sdp, data, data_size, call_id) &&
       srpc_out_queue_push(srpc, &srpc->sdp)) {
+#ifdef SRPC_WITH_PACKET_LOG_HOOKS
+    if (srpc->params.on_packet_sent != NULL) {
+      srpc->params.on_packet_sent(_srpc,
+                                  call_id,
+                                  data,
+                                  data_size,
+                                  srpc->params.user_params);
+    }
+#endif
 #ifndef __EH_DISABLED
     if (srpc->params.eh != 0) {
       eh_raise_event(srpc->params.eh);
@@ -2209,6 +2228,15 @@ _supla_int_t SRPC_ICACHE_FLASH srpc_ds_async_registerdevice_in_chunks(
     header_size += sizeof(TDS_SuplaRegisterDeviceHeader);
     srpc->params.data_write((char *)&srpc->sdp, header_size,
                             srpc->params.user_params);
+#ifdef SRPC_WITH_PACKET_LOG_HOOKS
+    if (srpc->params.on_packet_sent != NULL) {
+      srpc->params.on_packet_sent(_srpc,
+                                  call_id,
+                                  (char *)&srpc->sdp,
+                                  header_size,
+                                  srpc->params.user_params);
+    }
+#endif
     // send channels here
     const unsigned _supla_int_t channel_size = sizeof(TDS_SuplaDeviceChannel_D);
     for (int i = 0; i < registerdevice->channel_count; i++) {
@@ -2216,6 +2244,15 @@ _supla_int_t SRPC_ICACHE_FLASH srpc_ds_async_registerdevice_in_chunks(
       if (data == NULL) continue;
       srpc->params.data_write((char *)data, channel_size,
                               srpc->params.user_params);
+#ifdef SRPC_WITH_PACKET_LOG_HOOKS
+      if (srpc->params.on_packet_sent != NULL) {
+        srpc->params.on_packet_sent(_srpc,
+                                    call_id,
+                                    (char *)data,
+                                    channel_size,
+                                    srpc->params.user_params);
+      }
+#endif
     }
     srpc->params.data_write(sproto_tag, SUPLA_TAG_SIZE,
                             srpc->params.user_params);
@@ -2266,6 +2303,15 @@ _supla_int_t SRPC_ICACHE_FLASH srpc_ds_async_registerdevice_in_chunks_g(
     header_size += sizeof(TDS_SuplaRegisterDeviceHeader);
     srpc->params.data_write((char *)&srpc->sdp, header_size,
                             srpc->params.user_params);
+#ifdef SRPC_WITH_PACKET_LOG_HOOKS
+    if (srpc->params.on_packet_sent != NULL) {
+      srpc->params.on_packet_sent(_srpc,
+                                  call_id,
+                                  (char *)&srpc->sdp,
+                                  header_size,
+                                  srpc->params.user_params);
+    }
+#endif
     // send channels here
     const unsigned _supla_int_t channel_size = sizeof(TDS_SuplaDeviceChannel_E);
     for (int i = 0; i < registerdevice->channel_count; i++) {
@@ -2273,6 +2319,15 @@ _supla_int_t SRPC_ICACHE_FLASH srpc_ds_async_registerdevice_in_chunks_g(
       if (data == NULL) continue;
       srpc->params.data_write((char *)data, channel_size,
                               srpc->params.user_params);
+#ifdef SRPC_WITH_PACKET_LOG_HOOKS
+      if (srpc->params.on_packet_sent != NULL) {
+        srpc->params.on_packet_sent(_srpc,
+                                    call_id,
+                                    (char *)data,
+                                    channel_size,
+                                    srpc->params.user_params);
+      }
+#endif
     }
     srpc->params.data_write(sproto_tag, SUPLA_TAG_SIZE,
                             srpc->params.user_params);

--- a/supla-common/srpc.h
+++ b/supla-common/srpc.h
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
 // SPDX-License-Identifier: GPL-2.0-or-later
+
 #ifndef supladex_H_
 #define supladex_H_
 
@@ -46,6 +47,12 @@
 extern "C" {
 #endif
 
+#if defined(SUPLA_DEVICE) || defined(ESP8266) || defined(ESP32) || \
+    defined(__AVR__) || defined(ARDUINO_ARCH_ESP8266) || \
+    defined(ARDUINO_ARCH_ESP32) || defined(ARDUINO_ARCH_AVR)
+#define SRPC_WITH_PACKET_LOG_HOOKS
+#endif
+
 typedef _supla_int_t (*_func_srpc_DataRW)(void *buf, _supla_int_t count,
                                           void *user_params);
 typedef void (*_func_srpc_event_OnRemoteCallReceived)(
@@ -54,6 +61,20 @@ typedef void (*_func_srpc_event_OnRemoteCallReceived)(
 typedef void (*_func_srpc_event_BeforeCall)(void *_srpc,
                                             unsigned _supla_int_t call_id,
                                             void *user_params);
+#ifdef SRPC_WITH_PACKET_LOG_HOOKS
+typedef void (*_func_srpc_event_OnPacketSent)(
+    void *_srpc,
+    unsigned _supla_int_t call_id,
+    void *data,
+    unsigned _supla_int_t data_size,
+    void *user_params);
+typedef void (*_func_srpc_event_OnPacketReceived)(
+    void *_srpc,
+    unsigned _supla_int_t call_id,
+    void *data,
+    unsigned _supla_int_t data_size,
+    void *user_params);
+#endif
 typedef void (*_func_srpc_event_OnVersionError)(void *_srpc,
                                                 unsigned char remote_version,
                                                 void *user_params);
@@ -67,6 +88,10 @@ typedef struct {
   _func_srpc_event_OnRemoteCallReceived on_remote_call_received;
   _func_srpc_event_OnVersionError on_version_error;
   _func_srpc_event_BeforeCall before_async_call;
+#ifdef SRPC_WITH_PACKET_LOG_HOOKS
+  _func_srpc_event_OnPacketSent on_packet_sent;
+  _func_srpc_event_OnPacketReceived on_packet_received;
+#endif
   _func_srpc_event_OnMinVersionRequired on_min_version_required;
 
   TEventHandler *eh;

--- a/supla-common/srpc.h
+++ b/supla-common/srpc.h
@@ -1,20 +1,5 @@
-/*
- Copyright (C) AC SOFTWARE SP. Z O.O.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
+// SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
+// SPDX-License-Identifier: GPL-2.0-or-later
 #ifndef supladex_H_
 #define supladex_H_
 

--- a/supla-common/sthread.c
+++ b/supla-common/sthread.c
@@ -1,20 +1,5 @@
-/*
- Copyright (C) AC SOFTWARE SP. Z O.O.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
+// SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 #define _POSIX_C_SOURCE 200809L
 

--- a/supla-common/sthread.h
+++ b/supla-common/sthread.h
@@ -1,20 +1,5 @@
-/*
- Copyright (C) AC SOFTWARE SP. Z O.O.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
+// SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 #ifndef STHREAD_H_
 #define STHREAD_H_

--- a/supla-common/supla-socket.c
+++ b/supla-common/supla-socket.c
@@ -1,20 +1,5 @@
-/*
- Copyright (C) AC SOFTWARE SP. Z O.O.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
+// SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 #ifdef _WIN32
 

--- a/supla-common/supla-socket.h
+++ b/supla-common/supla-socket.h
@@ -1,20 +1,5 @@
-/*
- Copyright (C) AC SOFTWARE SP. Z O.O.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
+// SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 #ifndef supla_socket_H_
 #define supla_socket_H_

--- a/supla-common/test/MySqlShell.cpp
+++ b/supla-common/test/MySqlShell.cpp
@@ -1,20 +1,5 @@
-/*
- Copyright (C) AC SOFTWARE SP. Z O.O.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
+// SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "MySqlShell.h"
 

--- a/supla-common/test/MySqlShell.h
+++ b/supla-common/test/MySqlShell.h
@@ -1,20 +1,5 @@
-/*
- Copyright (C) AC SOFTWARE SP. Z O.O.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
+// SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 #ifndef MYSQLSHELL_H_
 #define MYSQLSHELL_H_

--- a/supla-common/test/ProtoTest.cpp
+++ b/supla-common/test/ProtoTest.cpp
@@ -1,20 +1,5 @@
-/*
- Copyright (C) AC SOFTWARE SP. Z O.O.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
+// SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "ProtoTest.h"
 

--- a/supla-common/test/ProtoTest.cpp
+++ b/supla-common/test/ProtoTest.cpp
@@ -239,6 +239,9 @@ TEST_F(ProtoTest, check_size_of_structures_and_types) {
             (unsigned int)SUPLA_DEVICE_CONFIG_MAXSIZE);
   EXPECT_LE(sizeof(TDeviceConfig_HomeScreenContent),
             (unsigned int)SUPLA_DEVICE_CONFIG_MAXSIZE);
+  EXPECT_EQ((unsigned int)8, sizeof(TDeviceConfig_InputActivation));
+  EXPECT_LE(sizeof(TDeviceConfig_InputActivation),
+            (unsigned int)SUPLA_DEVICE_CONFIG_MAXSIZE);
 
   EXPECT_EQ((unsigned int)8, sizeof(TCalCfg_RollerShutterSettings));
   EXPECT_LE(sizeof(TCalCfg_RollerShutterSettings),

--- a/supla-common/test/ProtoTest.h
+++ b/supla-common/test/ProtoTest.h
@@ -1,20 +1,5 @@
-/*
- Copyright (C) AC SOFTWARE SP. Z O.O.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
+// SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 #ifndef H_PROTO_TEST_H_
 #define H_PROTO_TEST_H_

--- a/supla-common/test/SafeArrayTest.cpp
+++ b/supla-common/test/SafeArrayTest.cpp
@@ -1,20 +1,5 @@
-/*
- Copyright (C) AC SOFTWARE SP. Z O.O.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
+// SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "SafeArrayTest.h"
 #include "gtest/gtest.h"  // NOLINT

--- a/supla-common/test/SafeArrayTest.h
+++ b/supla-common/test/SafeArrayTest.h
@@ -1,20 +1,5 @@
-/*
- Copyright (C) AC SOFTWARE SP. Z O.O.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
+// SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 #ifndef H_SAFEARRAY_TEST_H_
 #define H_SAFEARRAY_TEST_H_

--- a/supla-common/test/SrpcTest.cpp
+++ b/supla-common/test/SrpcTest.cpp
@@ -1,20 +1,5 @@
-/*
- Copyright (C) AC SOFTWARE SP. Z O.O.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
+// SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "SrpcTest.h"
 

--- a/supla-common/test/SrpcTest.h
+++ b/supla-common/test/SrpcTest.h
@@ -1,20 +1,5 @@
-/*
- Copyright (C) AC SOFTWARE SP. Z O.O.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
+// SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 #ifndef H_SRPC_TEST_H_
 #define H_SRPC_TEST_H_

--- a/supla-common/test/ToolsTest.cpp
+++ b/supla-common/test/ToolsTest.cpp
@@ -1,20 +1,5 @@
-/*
- Copyright (C) AC SOFTWARE SP. Z O.O.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
+// SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 #include "ToolsTest.h"
 

--- a/supla-common/test/ToolsTest.h
+++ b/supla-common/test/ToolsTest.h
@@ -1,20 +1,5 @@
-/*
- Copyright (C) AC SOFTWARE SP. Z O.O.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
+// SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 #ifndef H_TOOLS_TEST_H_
 #define H_TOOLS_TEST_H_

--- a/supla-common/tools.c
+++ b/supla-common/tools.c
@@ -1,20 +1,5 @@
-/*
- Copyright (C) AC SOFTWARE SP. Z O.O.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
+// SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 #ifndef ARDUINO
 

--- a/supla-common/tools.h
+++ b/supla-common/tools.h
@@ -1,20 +1,5 @@
-/*
- Copyright (C) AC SOFTWARE SP. Z O.O.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU General Public License
- as published by the Free Software Foundation; either version 2
- of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
-
- You should have received a copy of the GNU General Public License
- along with this program; if not, write to the Free Software
- Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- */
+// SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
+// SPDX-License-Identifier: GPL-2.0-or-later
 
 #ifndef ARDUINO
 

--- a/supla-server/src/cyclictasks/abstract_autodiscover_statistics.cpp
+++ b/supla-server/src/cyclictasks/abstract_autodiscover_statistics.cpp
@@ -51,7 +51,7 @@ void add_directional_power(double value, long *forward, long *reverse) {
     *forward += std::lround(value);
   }
 }
-}
+}  // namespace
 
 supla_abstract_autodiscover_statistics::
     supla_abstract_autodiscover_statistics()

--- a/supla-server/src/device/channel_config_sync_coordinator.cpp
+++ b/supla-server/src/device/channel_config_sync_coordinator.cpp
@@ -20,6 +20,7 @@
 
 #include <time.h>
 #include <sys/time.h>
+#include <vector>
 
 #include "device/devicechannel.h"
 #include "lck.h"

--- a/supla-server/src/device/devicechannel.cpp
+++ b/supla-server/src/device/devicechannel.cpp
@@ -22,6 +22,7 @@
 #include <string.h>
 
 #include <memory>
+#include <vector>
 
 #include "analyzer/data_analyzer_factory.h"
 #include "db/database.h"

--- a/supla-server/src/jsonconfig/device/device_json_config.cpp
+++ b/supla-server/src/jsonconfig/device/device_json_config.cpp
@@ -1520,7 +1520,8 @@ bool device_json_config::get_input_activation_config(
           &mode_string) ||
       !string_to_input_activation_mode(mode_string, &mode) ||
       !input_activation_json_to_available_modes(
-          cJSON_GetObjectItem(get_properties_root(), input_activation_available),
+          cJSON_GetObjectItem(get_properties_root(),
+                              input_activation_available),
           &available_modes) ||
       !(available_modes & mode)) {
     return false;

--- a/supla-server/src/jsonconfig/device/device_json_config.cpp
+++ b/supla-server/src/jsonconfig/device/device_json_config.cpp
@@ -38,7 +38,8 @@ const map<unsigned _supla_int16_t, string> device_json_config::field_map = {
     {SUPLA_DEVICE_CONFIG_FIELD_HOME_SCREEN_OFF_DELAY_TYPE, "offDelayType"},
     {SUPLA_DEVICE_CONFIG_FIELD_POWER_STATUS_LED, "powerStatusLed"},
     {SUPLA_DEVICE_CONFIG_FIELD_MODBUS, "modbus"},
-    {SUPLA_DEVICE_CONFIG_FIELD_FIRMWARE_UPDATE, "firmwareUpdatePolicy"}};
+    {SUPLA_DEVICE_CONFIG_FIELD_FIRMWARE_UPDATE, "firmwareUpdatePolicy"},
+    {SUPLA_DEVICE_CONFIG_FIELD_INPUT_ACTIVATION, "inputActivation"}};
 
 const map<unsigned _supla_int16_t, string>
     device_json_config::home_screen_content_map = {
@@ -95,6 +96,9 @@ const char device_json_config::min_allowed_temperature[] =
 
 const char device_json_config::max_allowed_temperature[] =
     "maxAllowedTemperatureSetpointFromLocalUI";
+
+const char device_json_config::input_activation_available[] =
+    "inputActivationAvailable";
 
 const char device_json_config::level_str[] = "level";
 const char device_json_config::adjustment_str[] = "adjustment";
@@ -158,6 +162,102 @@ unsigned char device_json_config::string_to_home_screen_content(
   }
 
   return SUPLA_DEVCFG_HOME_SCREEN_CONTENT_NONE;
+}
+
+string device_json_config::input_activation_mode_to_string(unsigned char mode) {
+  switch (mode) {
+    case SUPLA_DEVCFG_INPUT_ACTIVATION_GND:
+      return "GND";
+    case SUPLA_DEVCFG_INPUT_ACTIVATION_VCC:
+      return "VCC";
+  }
+
+  return "";
+}
+
+bool device_json_config::string_to_input_activation_mode(
+    const string &mode, unsigned char *value) {
+  if (!value) {
+    return false;
+  }
+
+  if (mode == "GND") {
+    *value = SUPLA_DEVCFG_INPUT_ACTIVATION_GND;
+    return true;
+  }
+
+  if (mode == "VCC") {
+    *value = SUPLA_DEVCFG_INPUT_ACTIVATION_VCC;
+    return true;
+  }
+
+  return false;
+}
+
+cJSON *device_json_config::input_activation_available_modes_to_json(
+    unsigned char modes) {
+  cJSON *result = cJSON_CreateArray();
+  if (!result) {
+    return nullptr;
+  }
+
+  if (modes & SUPLA_DEVCFG_INPUT_ACTIVATION_GND) {
+    cJSON *mode = cJSON_CreateString("GND");
+    if (!mode) {
+      cJSON_Delete(result);
+      return nullptr;
+    }
+    cJSON_AddItemToArray(result, mode);
+  }
+
+  if (modes & SUPLA_DEVCFG_INPUT_ACTIVATION_VCC) {
+    cJSON *mode = cJSON_CreateString("VCC");
+    if (!mode) {
+      cJSON_Delete(result);
+      return nullptr;
+    }
+    cJSON_AddItemToArray(result, mode);
+  }
+
+  return result;
+}
+
+bool device_json_config::input_activation_json_to_available_modes(
+    cJSON *json, unsigned char *modes) {
+  if (!json || !modes || !cJSON_IsArray(json)) {
+    return false;
+  }
+
+  unsigned char result = 0;
+  for (int a = 0; a < cJSON_GetArraySize(json); a++) {
+    cJSON *item = cJSON_GetArrayItem(json, a);
+    if (item && cJSON_IsString(item)) {
+      const char *value = cJSON_GetStringValue(item);
+      unsigned char mode = 0;
+      if (value && string_to_input_activation_mode(value, &mode)) {
+        result |= mode;
+      }
+    }
+  }
+
+  *modes = result;
+  return result != 0;
+}
+
+bool device_json_config::input_activation_config_is_valid(
+    const TDeviceConfig_InputActivation *cfg) {
+  if (!cfg || !(cfg->AvailableModes &
+                (SUPLA_DEVCFG_INPUT_ACTIVATION_GND |
+                 SUPLA_DEVCFG_INPUT_ACTIVATION_VCC))) {
+    return false;
+  }
+
+  if (cfg->Mode != SUPLA_DEVCFG_INPUT_ACTIVATION_GND &&
+      cfg->Mode != SUPLA_DEVCFG_INPUT_ACTIVATION_VCC) {
+    return false;
+  }
+
+  return (cfg->AvailableModes & cfg->Mode) != 0;
 }
 
 void device_json_config::set_status_led(TDeviceConfig_StatusLed *status_led) {
@@ -740,6 +840,44 @@ void device_json_config::set_firmware_update_config(
   }
 }
 
+void device_json_config::set_input_activation_config(
+    TDeviceConfig_InputActivation *cfg) {
+  if (!input_activation_config_is_valid(cfg)) {
+    return;
+  }
+
+  string mode = input_activation_mode_to_string(cfg->Mode);
+  cJSON *available_modes =
+      input_activation_available_modes_to_json(cfg->AvailableModes);
+  if (mode.empty() || !available_modes) {
+    cJSON_Delete(available_modes);
+    return;
+  }
+
+  cJSON *properties_root = get_properties_root();
+  if (!properties_root) {
+    cJSON_Delete(available_modes);
+    return;
+  }
+
+  cJSON *old_available_modes =
+      cJSON_GetObjectItem(properties_root, input_activation_available);
+  if (old_available_modes) {
+    cJSON_Delete(
+        cJSON_DetachItemViaPointer(properties_root, old_available_modes));
+  }
+
+  if (!cJSON_AddItemToObject(properties_root, input_activation_available,
+                             available_modes)) {
+    cJSON_Delete(available_modes);
+    return;
+  }
+
+  set_item_value(get_user_root(),
+                 field_map.at(SUPLA_DEVICE_CONFIG_FIELD_INPUT_ACTIVATION),
+                 cJSON_String, true, nullptr, mode.c_str(), 0);
+}
+
 cJSON *device_json_config::get_root(bool create, bool user,
                                     unsigned _supla_int64_t field) {
   cJSON *root = user ? get_user_root() : get_properties_root();
@@ -914,6 +1052,12 @@ void device_json_config::set_config(TSDS_SetDeviceConfig *config) {
           if (left >= (size = sizeof(TDeviceConfig_FirmwareUpdate))) {
             set_firmware_update_config(
                 static_cast<TDeviceConfig_FirmwareUpdate *>(ptr));
+          }
+          break;
+        case SUPLA_DEVICE_CONFIG_FIELD_INPUT_ACTIVATION:
+          if (left >= (size = sizeof(TDeviceConfig_InputActivation))) {
+            set_input_activation_config(
+                static_cast<TDeviceConfig_InputActivation *>(ptr));
           }
           break;
       }
@@ -1251,6 +1395,34 @@ bool device_json_config::get_firmware_update_config(
   return false;
 }
 
+bool device_json_config::get_input_activation_config(
+    TDeviceConfig_InputActivation *cfg) {
+  if (!cfg) {
+    return false;
+  }
+
+  string mode_string;
+  unsigned char mode = 0;
+  unsigned char available_modes = 0;
+
+  if (!get_string(
+          get_user_root(),
+          field_map.at(SUPLA_DEVICE_CONFIG_FIELD_INPUT_ACTIVATION).c_str(),
+          &mode_string) ||
+      !string_to_input_activation_mode(mode_string, &mode) ||
+      !input_activation_json_to_available_modes(
+          cJSON_GetObjectItem(get_properties_root(), input_activation_available),
+          &available_modes) ||
+      !(available_modes & mode)) {
+    return false;
+  }
+
+  cfg->AvailableModes = available_modes;
+  cfg->Mode = mode;
+  memset(cfg->Reserved, 0, sizeof(cfg->Reserved));
+  return true;
+}
+
 void device_json_config::get_config(TSDS_SetDeviceConfig *config,
                                     unsigned _supla_int64_t fields,
                                     unsigned _supla_int64_t *fields_left) {
@@ -1342,6 +1514,12 @@ void device_json_config::get_config(TSDS_SetDeviceConfig *config,
                       get_firmware_update_config(
                           static_cast<TDeviceConfig_FirmwareUpdate *>(ptr));
           break;
+        case SUPLA_DEVICE_CONFIG_FIELD_INPUT_ACTIVATION:
+          field_set =
+              left >= (size = sizeof(TDeviceConfig_InputActivation)) &&
+              get_input_activation_config(
+                  static_cast<TDeviceConfig_InputActivation *>(ptr));
+          break;
       }
 
       if (field_set) {
@@ -1401,6 +1579,15 @@ void device_json_config::leave_only_thise_fields(
     }
   }
 
+  if (!(fields & SUPLA_DEVICE_CONFIG_FIELD_INPUT_ACTIVATION)) {
+    cJSON *item =
+        cJSON_GetObjectItem(get_properties_root(), input_activation_available);
+    if (item) {
+      cJSON_DetachItemViaPointer(get_properties_root(), item);
+      cJSON_Delete(item);
+    }
+  }
+
   remove_empty_sub_roots();
 }
 
@@ -1418,6 +1605,15 @@ void device_json_config::remove_fields(unsigned _supla_int64_t fields) {
     }
   }
 
+  if (fields & SUPLA_DEVICE_CONFIG_FIELD_INPUT_ACTIVATION) {
+    cJSON *item =
+        cJSON_GetObjectItem(get_properties_root(), input_activation_available);
+    if (item) {
+      cJSON_DetachItemViaPointer(get_properties_root(), item);
+      cJSON_Delete(item);
+    }
+  }
+
   remove_empty_sub_roots();
 }
 
@@ -1426,7 +1622,8 @@ void device_json_config::merge(supla_json_config *_dst) {
 
   map<unsigned _supla_int16_t, string> props_fields = {
       {1, content_available},
-      {2, field_map.at(SUPLA_DEVICE_CONFIG_FIELD_MODBUS)}};
+      {2, field_map.at(SUPLA_DEVICE_CONFIG_FIELD_MODBUS)},
+      {4, input_activation_available}};
 
   map<cJSON *, map<unsigned _supla_int16_t, string>> map;
 

--- a/supla-server/src/jsonconfig/device/device_json_config.cpp
+++ b/supla-server/src/jsonconfig/device/device_json_config.cpp
@@ -170,6 +170,8 @@ string device_json_config::input_activation_mode_to_string(unsigned char mode) {
       return "GND";
     case SUPLA_DEVCFG_INPUT_ACTIVATION_VCC:
       return "VCC";
+    case SUPLA_DEVCFG_INPUT_ACTIVATION_GND_OR_VCC:
+      return "GND_OR_VCC";
   }
 
   return "";
@@ -188,6 +190,11 @@ bool device_json_config::string_to_input_activation_mode(
 
   if (mode == "VCC") {
     *value = SUPLA_DEVCFG_INPUT_ACTIVATION_VCC;
+    return true;
+  }
+
+  if (mode == "GND_OR_VCC") {
+    *value = SUPLA_DEVCFG_INPUT_ACTIVATION_GND_OR_VCC;
     return true;
   }
 
@@ -212,6 +219,15 @@ cJSON *device_json_config::input_activation_available_modes_to_json(
 
   if (modes & SUPLA_DEVCFG_INPUT_ACTIVATION_VCC) {
     cJSON *mode = cJSON_CreateString("VCC");
+    if (!mode) {
+      cJSON_Delete(result);
+      return nullptr;
+    }
+    cJSON_AddItemToArray(result, mode);
+  }
+
+  if (modes & SUPLA_DEVCFG_INPUT_ACTIVATION_GND_OR_VCC) {
+    cJSON *mode = cJSON_CreateString("GND_OR_VCC");
     if (!mode) {
       cJSON_Delete(result);
       return nullptr;
@@ -248,12 +264,14 @@ bool device_json_config::input_activation_config_is_valid(
     const TDeviceConfig_InputActivation *cfg) {
   if (!cfg || !(cfg->AvailableModes &
                 (SUPLA_DEVCFG_INPUT_ACTIVATION_GND |
-                 SUPLA_DEVCFG_INPUT_ACTIVATION_VCC))) {
+                 SUPLA_DEVCFG_INPUT_ACTIVATION_VCC |
+                 SUPLA_DEVCFG_INPUT_ACTIVATION_GND_OR_VCC))) {
     return false;
   }
 
   if (cfg->Mode != SUPLA_DEVCFG_INPUT_ACTIVATION_GND &&
-      cfg->Mode != SUPLA_DEVCFG_INPUT_ACTIVATION_VCC) {
+      cfg->Mode != SUPLA_DEVCFG_INPUT_ACTIVATION_VCC &&
+      cfg->Mode != SUPLA_DEVCFG_INPUT_ACTIVATION_GND_OR_VCC) {
     return false;
   }
 

--- a/supla-server/src/jsonconfig/device/device_json_config.h
+++ b/supla-server/src/jsonconfig/device/device_json_config.h
@@ -35,6 +35,7 @@ class device_json_config : public supla_json_config {
   static const char disabled_str[];
   static const char min_allowed_temperature[];
   static const char max_allowed_temperature[];
+  static const char input_activation_available[];
   static const char level_str[];
   static const char adjustment_str[];
 
@@ -44,6 +45,14 @@ class device_json_config : public supla_json_config {
   unsigned char string_to_power_status_led(const std::string &status);
   std::string home_screen_content_to_string(unsigned char status);
   unsigned char string_to_home_screen_content(const std::string &status);
+  std::string input_activation_mode_to_string(unsigned char mode);
+  bool string_to_input_activation_mode(const std::string &mode,
+                                       unsigned char *value);
+  cJSON *input_activation_available_modes_to_json(unsigned char modes);
+  bool input_activation_json_to_available_modes(cJSON *json,
+                                                unsigned char *modes);
+  bool input_activation_config_is_valid(
+      const TDeviceConfig_InputActivation *cfg);
   std::string modbus_role_to_string(unsigned char role);
   unsigned char string_to_modbus_role(const std::string &role);
   std::string modbus_serial_mode_to_string(unsigned char mode);
@@ -87,6 +96,7 @@ class device_json_config : public supla_json_config {
   void set_home_screen_content(TDeviceConfig_HomeScreenContent *content);
   void set_modbus_config(TDeviceConfig_Modbus *cfg);
   void set_firmware_update_config(TDeviceConfig_FirmwareUpdate *cfg);
+  void set_input_activation_config(TDeviceConfig_InputActivation *cfg);
   void remove_empty_sub_roots();
 
  public:
@@ -115,6 +125,7 @@ class device_json_config : public supla_json_config {
       TDeviceConfig_HomeScreenOffDelayType *type);
   bool get_modbus_config(TDeviceConfig_Modbus *cfg);
   bool get_firmware_update_config(TDeviceConfig_FirmwareUpdate *cfg);
+  bool get_input_activation_config(TDeviceConfig_InputActivation *cfg);
 };
 
 #endif /* DEVICE_JSON_CONFIG_H_ */

--- a/supla-server/src/test/jsonconfig/device/DeviceConfigTest.cpp
+++ b/supla-server/src/test/jsonconfig/device/DeviceConfigTest.cpp
@@ -173,7 +173,8 @@ TEST_F(DeviceConfigTest, allFields) {
       (TDeviceConfig_InputActivation *)&sds_cfg.Config[sds_cfg.ConfigSize];
   input_activation->AvailableModes =
       SUPLA_DEVCFG_INPUT_ACTIVATION_GND |
-      SUPLA_DEVCFG_INPUT_ACTIVATION_VCC;
+      SUPLA_DEVCFG_INPUT_ACTIVATION_VCC |
+      SUPLA_DEVCFG_INPUT_ACTIVATION_GND_OR_VCC;
   input_activation->Mode = SUPLA_DEVCFG_INPUT_ACTIVATION_VCC;
   sds_cfg.ConfigSize += sizeof(TDeviceConfig_InputActivation);
   ASSERT_LE(sds_cfg.ConfigSize, SUPLA_DEVICE_CONFIG_MAXSIZE);
@@ -221,7 +222,7 @@ TEST_F(DeviceConfigTest, allFields) {
       "\"availableProtocols\":[\"MASTER\",\"SLAVE\",\"RTU\",\"ASCII\",\"TCP\","
       "\"UDP\"],\"availableBaudrates\":[4800,9600,19200,38400,57600,115200],"
       "\"availableStopbits\":[\"ONE\",\"TWO\",\"ONE_AND_HALF\"]},"
-      "\"inputActivationAvailable\":[\"GND\",\"VCC\"]}");
+      "\"inputActivationAvailable\":[\"GND\",\"VCC\",\"GND_OR_VCC\"]}");
 
   cfg2.set_properties(str);
 
@@ -240,7 +241,8 @@ TEST_F(DeviceConfigTest, allFields) {
                  .Config[input_activation_offset])
                 ->AvailableModes,
             SUPLA_DEVCFG_INPUT_ACTIVATION_GND |
-                SUPLA_DEVCFG_INPUT_ACTIVATION_VCC);
+                SUPLA_DEVCFG_INPUT_ACTIVATION_VCC |
+                SUPLA_DEVCFG_INPUT_ACTIVATION_GND_OR_VCC);
   EXPECT_EQ(((TDeviceConfig_InputActivation *)&sds_cfg2
                  .Config[input_activation_offset])
                 ->Mode,
@@ -257,8 +259,9 @@ TEST_F(DeviceConfigTest, allFields) {
 TEST_F(DeviceConfigTest, inputActivation) {
   TDeviceConfig_InputActivation input = {};
   input.AvailableModes = SUPLA_DEVCFG_INPUT_ACTIVATION_GND |
-                         SUPLA_DEVCFG_INPUT_ACTIVATION_VCC | (1U << 7);
-  input.Mode = SUPLA_DEVCFG_INPUT_ACTIVATION_VCC;
+                         SUPLA_DEVCFG_INPUT_ACTIVATION_VCC |
+                         SUPLA_DEVCFG_INPUT_ACTIVATION_GND_OR_VCC | (1U << 7);
+  input.Mode = SUPLA_DEVCFG_INPUT_ACTIVATION_GND_OR_VCC;
 
   TSDS_SetDeviceConfig sds_cfg = {};
   sds_cfg.Fields = SUPLA_DEVICE_CONFIG_FIELD_INPUT_ACTIVATION;
@@ -270,16 +273,18 @@ TEST_F(DeviceConfigTest, inputActivation) {
 
   char *str = cfg1.get_user_config();
   ASSERT_NE(str, nullptr);
-  EXPECT_STREQ(str, "{\"inputActivation\":\"VCC\"}");
+  EXPECT_STREQ(str, "{\"inputActivation\":\"GND_OR_VCC\"}");
   free(str);
 
   str = cfg1.get_properties();
   ASSERT_NE(str, nullptr);
-  EXPECT_STREQ(str, "{\"inputActivationAvailable\":[\"GND\",\"VCC\"]}");
+  EXPECT_STREQ(
+      str,
+      "{\"inputActivationAvailable\":[\"GND\",\"VCC\",\"GND_OR_VCC\"]}");
   cfg2.set_properties(str);
   free(str);
 
-  cfg2.set_user_config("{\"inputActivation\":\"VCC\"}");
+  cfg2.set_user_config("{\"inputActivation\":\"GND_OR_VCC\"}");
   TSDS_SetDeviceConfig sds_cfg2 = {};
   unsigned _supla_int64_t fields_left = 0xFFFFFFFFFFFFFFFF;
   cfg2.get_config(&sds_cfg2, &fields_left);
@@ -289,9 +294,10 @@ TEST_F(DeviceConfigTest, inputActivation) {
   EXPECT_EQ(sds_cfg2.ConfigSize, sizeof(TDeviceConfig_InputActivation));
   EXPECT_EQ(((TDeviceConfig_InputActivation *)sds_cfg2.Config)->AvailableModes,
             SUPLA_DEVCFG_INPUT_ACTIVATION_GND |
-                SUPLA_DEVCFG_INPUT_ACTIVATION_VCC);
+                SUPLA_DEVCFG_INPUT_ACTIVATION_VCC |
+                SUPLA_DEVCFG_INPUT_ACTIVATION_GND_OR_VCC);
   EXPECT_EQ(((TDeviceConfig_InputActivation *)sds_cfg2.Config)->Mode,
-            SUPLA_DEVCFG_INPUT_ACTIVATION_VCC);
+            SUPLA_DEVCFG_INPUT_ACTIVATION_GND_OR_VCC);
   EXPECT_EQ(memcmp(((TDeviceConfig_InputActivation *)sds_cfg2.Config)->Reserved,
                    input.Reserved, sizeof(input.Reserved)),
             0);
@@ -336,6 +342,18 @@ TEST_F(DeviceConfigTest, inputActivation) {
             SUPLA_DEVCFG_INPUT_ACTIVATION_VCC);
   EXPECT_EQ(((TDeviceConfig_InputActivation *)sds_cfg.Config)->Mode,
             SUPLA_DEVCFG_INPUT_ACTIVATION_VCC);
+
+  json_config.set_user_config("{\"inputActivation\":\"GND_OR_VCC\"}");
+  json_config.set_properties(
+      "{\"inputActivationAvailable\":[\"GND_OR_VCC\"]}");
+  sds_cfg = {};
+  json_config.get_config(&sds_cfg, nullptr);
+  EXPECT_EQ(sds_cfg.Fields, SUPLA_DEVICE_CONFIG_FIELD_INPUT_ACTIVATION);
+  EXPECT_EQ(sds_cfg.ConfigSize, sizeof(TDeviceConfig_InputActivation));
+  EXPECT_EQ(((TDeviceConfig_InputActivation *)sds_cfg.Config)->AvailableModes,
+            SUPLA_DEVCFG_INPUT_ACTIVATION_GND_OR_VCC);
+  EXPECT_EQ(((TDeviceConfig_InputActivation *)sds_cfg.Config)->Mode,
+            SUPLA_DEVCFG_INPUT_ACTIVATION_GND_OR_VCC);
 }
 
 TEST_F(DeviceConfigTest, inputActivationRejectsInvalidValues) {

--- a/supla-server/src/test/jsonconfig/device/DeviceConfigTest.cpp
+++ b/supla-server/src/test/jsonconfig/device/DeviceConfigTest.cpp
@@ -94,7 +94,8 @@ TEST_F(DeviceConfigTest, allFields) {
                    SUPLA_DEVICE_CONFIG_FIELD_HOME_SCREEN_CONTENT |
                    SUPLA_DEVICE_CONFIG_FIELD_HOME_SCREEN_OFF_DELAY_TYPE |
                    SUPLA_DEVICE_CONFIG_FIELD_MODBUS |
-                   SUPLA_DEVICE_CONFIG_FIELD_FIRMWARE_UPDATE;
+                   SUPLA_DEVICE_CONFIG_FIELD_FIRMWARE_UPDATE |
+                   SUPLA_DEVICE_CONFIG_FIELD_INPUT_ACTIVATION;
 
   ((TDeviceConfig_StatusLed *)&sds_cfg.Config[sds_cfg.ConfigSize])
       ->StatusLedType = SUPLA_DEVCFG_STATUS_LED_ALWAYS_OFF;
@@ -167,6 +168,29 @@ TEST_F(DeviceConfigTest, allFields) {
   sds_cfg.ConfigSize += sizeof(TDeviceConfig_FirmwareUpdate);
   ASSERT_LE(sds_cfg.ConfigSize, SUPLA_DEVICE_CONFIG_MAXSIZE);
 
+  size_t input_activation_offset = sds_cfg.ConfigSize;
+  TDeviceConfig_InputActivation *input_activation =
+      (TDeviceConfig_InputActivation *)&sds_cfg.Config[sds_cfg.ConfigSize];
+  input_activation->AvailableModes =
+      SUPLA_DEVCFG_INPUT_ACTIVATION_GND |
+      SUPLA_DEVCFG_INPUT_ACTIVATION_VCC;
+  input_activation->Mode = SUPLA_DEVCFG_INPUT_ACTIVATION_VCC;
+  sds_cfg.ConfigSize += sizeof(TDeviceConfig_InputActivation);
+  ASSERT_LE(sds_cfg.ConfigSize, SUPLA_DEVICE_CONFIG_MAXSIZE);
+
+  EXPECT_EQ(
+      sds_cfg.ConfigSize,
+      sizeof(TDeviceConfig_StatusLed) + sizeof(TDeviceConfig_ScreenBrightness) +
+          sizeof(TDeviceConfig_ButtonVolume) +
+          sizeof(TDeviceConfig_DisableUserInterface) +
+          sizeof(TDeviceConfig_AutomaticTimeSync) +
+          sizeof(TDeviceConfig_HomeScreenOffDelay) +
+          sizeof(TDeviceConfig_HomeScreenContent) +
+          sizeof(TDeviceConfig_HomeScreenOffDelayType) +
+          sizeof(TDeviceConfig_PowerStatusLed) + sizeof(TDeviceConfig_Modbus) +
+          sizeof(TDeviceConfig_FirmwareUpdate) +
+          sizeof(TDeviceConfig_InputActivation));
+
   device_json_config cfg;
   cfg.set_config(&sds_cfg);
   char *str = cfg.get_user_config();
@@ -180,7 +204,7 @@ TEST_F(DeviceConfigTest, allFields) {
       "\"ENABLED\",\"modbus\":{\"role\":\"SLAVE\",\"modbusAddress\":123,"
       "\"slaveTimeoutMs\":0,\"serialConfig\":{\"mode\":\"RTU\",\"baudRate\":"
       "9600,\"stopBits\":\"ONE\"},\"networkConfig\":{\"mode\":\"TCP\",\"port\":"
-      "88}},\"firmwareUpdatePolicy\":\"ALL_ENABLED\"}");
+      "88}},\"firmwareUpdatePolicy\":\"ALL_ENABLED\",\"inputActivation\":\"VCC\"}");
 
   device_json_config cfg2;
   cfg2.set_user_config(str);
@@ -196,7 +220,8 @@ TEST_F(DeviceConfigTest, allFields) {
       "AUX_TEMPERATURE\",\"MODE_OR_TEMPERATURE\"],\"modbus\":{"
       "\"availableProtocols\":[\"MASTER\",\"SLAVE\",\"RTU\",\"ASCII\",\"TCP\","
       "\"UDP\"],\"availableBaudrates\":[4800,9600,19200,38400,57600,115200],"
-      "\"availableStopbits\":[\"ONE\",\"TWO\",\"ONE_AND_HALF\"]}}");
+      "\"availableStopbits\":[\"ONE\",\"TWO\",\"ONE_AND_HALF\"]},"
+      "\"inputActivationAvailable\":[\"GND\",\"VCC\"]}");
 
   cfg2.set_properties(str);
 
@@ -211,12 +236,215 @@ TEST_F(DeviceConfigTest, allFields) {
             SUPLA_DEVCFG_HOME_SCREEN_CONTENT_MODE_OR_TEMPERATURE |
                 (SUPLA_DEVCFG_HOME_SCREEN_CONTENT_MODE_OR_TEMPERATURE - 1));
 
+  EXPECT_EQ(((TDeviceConfig_InputActivation *)&sds_cfg2
+                 .Config[input_activation_offset])
+                ->AvailableModes,
+            SUPLA_DEVCFG_INPUT_ACTIVATION_GND |
+                SUPLA_DEVCFG_INPUT_ACTIVATION_VCC);
+  EXPECT_EQ(((TDeviceConfig_InputActivation *)&sds_cfg2
+                 .Config[input_activation_offset])
+                ->Mode,
+            SUPLA_DEVCFG_INPUT_ACTIVATION_VCC);
+
   ((TDeviceConfig_HomeScreenContent *)&sds_cfg2
        .Config[home_screen_content_offset])
       ->ContentAvailable = 0xFFFFFFFFFFFFFFFF;
 
   EXPECT_EQ(sds_cfg.Fields, sds_cfg2.Fields);
   EXPECT_EQ(memcmp(sds_cfg.Config, sds_cfg2.Config, sds_cfg.ConfigSize), 0);
+}
+
+TEST_F(DeviceConfigTest, inputActivation) {
+  TDeviceConfig_InputActivation input = {};
+  input.AvailableModes = SUPLA_DEVCFG_INPUT_ACTIVATION_GND |
+                         SUPLA_DEVCFG_INPUT_ACTIVATION_VCC | (1U << 7);
+  input.Mode = SUPLA_DEVCFG_INPUT_ACTIVATION_VCC;
+
+  TSDS_SetDeviceConfig sds_cfg = {};
+  sds_cfg.Fields = SUPLA_DEVICE_CONFIG_FIELD_INPUT_ACTIVATION;
+  sds_cfg.ConfigSize = sizeof(input);
+  memcpy(sds_cfg.Config, &input, sizeof(input));
+
+  device_json_config cfg1, cfg2;
+  cfg1.set_config(&sds_cfg);
+
+  char *str = cfg1.get_user_config();
+  ASSERT_NE(str, nullptr);
+  EXPECT_STREQ(str, "{\"inputActivation\":\"VCC\"}");
+  free(str);
+
+  str = cfg1.get_properties();
+  ASSERT_NE(str, nullptr);
+  EXPECT_STREQ(str, "{\"inputActivationAvailable\":[\"GND\",\"VCC\"]}");
+  cfg2.set_properties(str);
+  free(str);
+
+  cfg2.set_user_config("{\"inputActivation\":\"VCC\"}");
+  TSDS_SetDeviceConfig sds_cfg2 = {};
+  unsigned _supla_int64_t fields_left = 0xFFFFFFFFFFFFFFFF;
+  cfg2.get_config(&sds_cfg2, &fields_left);
+
+  EXPECT_EQ(fields_left, 0);
+  EXPECT_EQ(sds_cfg2.Fields, SUPLA_DEVICE_CONFIG_FIELD_INPUT_ACTIVATION);
+  EXPECT_EQ(sds_cfg2.ConfigSize, sizeof(TDeviceConfig_InputActivation));
+  EXPECT_EQ(((TDeviceConfig_InputActivation *)sds_cfg2.Config)->AvailableModes,
+            SUPLA_DEVCFG_INPUT_ACTIVATION_GND |
+                SUPLA_DEVCFG_INPUT_ACTIVATION_VCC);
+  EXPECT_EQ(((TDeviceConfig_InputActivation *)sds_cfg2.Config)->Mode,
+            SUPLA_DEVCFG_INPUT_ACTIVATION_VCC);
+  EXPECT_EQ(memcmp(((TDeviceConfig_InputActivation *)sds_cfg2.Config)->Reserved,
+                   input.Reserved, sizeof(input.Reserved)),
+            0);
+
+  input.AvailableModes = SUPLA_DEVCFG_INPUT_ACTIVATION_GND;
+  input.Mode = SUPLA_DEVCFG_INPUT_ACTIVATION_GND;
+  sds_cfg = {};
+  sds_cfg.Fields = SUPLA_DEVICE_CONFIG_FIELD_INPUT_ACTIVATION;
+  sds_cfg.ConfigSize = sizeof(input);
+  memcpy(sds_cfg.Config, &input, sizeof(input));
+  device_json_config gnd_config;
+  gnd_config.set_config(&sds_cfg);
+
+  str = gnd_config.get_user_config();
+  ASSERT_NE(str, nullptr);
+  EXPECT_STREQ(str, "{\"inputActivation\":\"GND\"}");
+  free(str);
+  str = gnd_config.get_properties();
+  ASSERT_NE(str, nullptr);
+  EXPECT_STREQ(str, "{\"inputActivationAvailable\":[\"GND\"]}");
+  free(str);
+
+  device_json_config json_config;
+  json_config.set_user_config("{\"inputActivation\":\"GND\"}");
+  json_config.set_properties("{\"inputActivationAvailable\":[\"GND\"]}");
+  sds_cfg = {};
+  json_config.get_config(&sds_cfg, nullptr);
+  EXPECT_EQ(sds_cfg.Fields, SUPLA_DEVICE_CONFIG_FIELD_INPUT_ACTIVATION);
+  EXPECT_EQ(sds_cfg.ConfigSize, sizeof(TDeviceConfig_InputActivation));
+  EXPECT_EQ(((TDeviceConfig_InputActivation *)sds_cfg.Config)->AvailableModes,
+            SUPLA_DEVCFG_INPUT_ACTIVATION_GND);
+  EXPECT_EQ(((TDeviceConfig_InputActivation *)sds_cfg.Config)->Mode,
+            SUPLA_DEVCFG_INPUT_ACTIVATION_GND);
+
+  json_config.set_user_config("{\"inputActivation\":\"VCC\"}");
+  json_config.set_properties("{\"inputActivationAvailable\":[\"VCC\"]}");
+  sds_cfg = {};
+  json_config.get_config(&sds_cfg, nullptr);
+  EXPECT_EQ(sds_cfg.Fields, SUPLA_DEVICE_CONFIG_FIELD_INPUT_ACTIVATION);
+  EXPECT_EQ(sds_cfg.ConfigSize, sizeof(TDeviceConfig_InputActivation));
+  EXPECT_EQ(((TDeviceConfig_InputActivation *)sds_cfg.Config)->AvailableModes,
+            SUPLA_DEVCFG_INPUT_ACTIVATION_VCC);
+  EXPECT_EQ(((TDeviceConfig_InputActivation *)sds_cfg.Config)->Mode,
+            SUPLA_DEVCFG_INPUT_ACTIVATION_VCC);
+}
+
+TEST_F(DeviceConfigTest, inputActivationRejectsInvalidValues) {
+  device_json_config cfg;
+  cfg.set_user_config("{\"inputActivation\":\"GND\"}");
+  cfg.set_properties("{\"inputActivationAvailable\":[\"GND\"]}");
+
+  char *before_user = cfg.get_user_config();
+  char *before_properties = cfg.get_properties();
+  ASSERT_NE(before_user, nullptr);
+  ASSERT_NE(before_properties, nullptr);
+
+  TDeviceConfig_InputActivation input = {};
+  input.AvailableModes = SUPLA_DEVCFG_INPUT_ACTIVATION_GND |
+                         SUPLA_DEVCFG_INPUT_ACTIVATION_VCC;
+  input.Mode = SUPLA_DEVCFG_INPUT_ACTIVATION_GND |
+               SUPLA_DEVCFG_INPUT_ACTIVATION_VCC;
+
+  TSDS_SetDeviceConfig sds_cfg = {};
+  sds_cfg.Fields = SUPLA_DEVICE_CONFIG_FIELD_INPUT_ACTIVATION;
+  sds_cfg.ConfigSize = sizeof(input);
+  memcpy(sds_cfg.Config, &input, sizeof(input));
+  cfg.set_config(&sds_cfg);
+
+  char *after_user = cfg.get_user_config();
+  char *after_properties = cfg.get_properties();
+  ASSERT_NE(after_user, nullptr);
+  ASSERT_NE(after_properties, nullptr);
+  EXPECT_STREQ(after_user, before_user);
+  EXPECT_STREQ(after_properties, before_properties);
+  free(before_user);
+  free(before_properties);
+  free(after_user);
+  free(after_properties);
+
+  input.AvailableModes = SUPLA_DEVCFG_INPUT_ACTIVATION_GND;
+  input.Mode = SUPLA_DEVCFG_INPUT_ACTIVATION_VCC;
+  sds_cfg = {};
+  sds_cfg.Fields = SUPLA_DEVICE_CONFIG_FIELD_INPUT_ACTIVATION;
+  sds_cfg.ConfigSize = sizeof(input);
+  memcpy(sds_cfg.Config, &input, sizeof(input));
+  cfg.set_config(&sds_cfg);
+
+  TDeviceConfig_InputActivation restored = {};
+  EXPECT_TRUE(cfg.get_input_activation_config(&restored));
+  EXPECT_EQ(restored.AvailableModes, SUPLA_DEVCFG_INPUT_ACTIVATION_GND);
+  EXPECT_EQ(restored.Mode, SUPLA_DEVCFG_INPUT_ACTIVATION_GND);
+
+  cfg.set_user_config("{\"inputActivation\":\"INVALID\"}");
+  cfg.set_properties("{\"inputActivationAvailable\":[\"GND\"]}");
+  restored.AvailableModes = 0xA5;
+  restored.Mode = 0xA5;
+  memset(restored.Reserved, 0xA5, sizeof(restored.Reserved));
+  EXPECT_FALSE(cfg.get_input_activation_config(&restored));
+  EXPECT_EQ(restored.AvailableModes, 0xA5);
+  EXPECT_EQ(restored.Mode, 0xA5);
+
+  cfg.set_user_config("{\"inputActivation\":\"VCC\"}");
+  cfg.set_properties("{\"inputActivationAvailable\":[\"GND\"]}");
+  EXPECT_FALSE(cfg.get_input_activation_config(&restored));
+
+  sds_cfg = {};
+  unsigned _supla_int64_t fields_left = 0;
+  cfg.get_config(&sds_cfg, SUPLA_DEVICE_CONFIG_FIELD_INPUT_ACTIVATION,
+                 &fields_left);
+  EXPECT_EQ(sds_cfg.Fields, 0);
+  EXPECT_EQ(sds_cfg.ConfigSize, 0);
+  EXPECT_EQ(fields_left, 0);
+}
+
+TEST_F(DeviceConfigTest, inputActivationPropertiesLifecycle) {
+  device_json_config source, destination;
+  source.set_user_config("{\"inputActivation\":\"VCC\"}");
+  source.set_properties("{\"inputActivationAvailable\":[\"GND\",\"VCC\"]}");
+  destination.set_user_config("{\"inputActivation\":\"GND\"}");
+  destination.set_properties("{\"inputActivationAvailable\":[\"GND\"]}");
+
+  source.merge(&destination);
+
+  char *str = destination.get_user_config();
+  ASSERT_NE(str, nullptr);
+  EXPECT_STREQ(str, "{\"inputActivation\":\"VCC\"}");
+  free(str);
+  str = destination.get_properties();
+  ASSERT_NE(str, nullptr);
+  EXPECT_STREQ(str, "{\"inputActivationAvailable\":[\"GND\",\"VCC\"]}");
+  free(str);
+
+  destination.remove_fields(SUPLA_DEVICE_CONFIG_FIELD_INPUT_ACTIVATION);
+  str = destination.get_user_config();
+  ASSERT_NE(str, nullptr);
+  EXPECT_STREQ(str, "{}");
+  free(str);
+  str = destination.get_properties();
+  ASSERT_NE(str, nullptr);
+  EXPECT_STREQ(str, "{}");
+  free(str);
+
+  source.set_user_config("{\"inputActivation\":\"GND\"}");
+  source.set_properties("{\"inputActivationAvailable\":[\"GND\"]}");
+  source.leave_only_thise_fields(0);
+  str = source.get_user_config();
+  ASSERT_NE(str, nullptr);
+  EXPECT_STREQ(str, "{}");
+  free(str);
+  str = source.get_properties();
+  ASSERT_NE(str, nullptr);
+  EXPECT_STREQ(str, "{}");
+  free(str);
 }
 
 TEST_F(DeviceConfigTest, twoFieldsSlightlyApart) {
@@ -686,7 +914,7 @@ TEST_F(DeviceConfigTest, availableFields) {
       "{\"statusLed\":2,\"screenBrightness\":{\"level\":24},\"buttonVolume\":"
       "100,\"userInterface\":{\"disabled\":false},\"automaticTimeSync\":true,"
       "\"homeScreen\": {\"offDelay\":123,\"content\": "
-      "\"TEMPERATURE_AND_HUMIDITY\"}}");
+      "\"TEMPERATURE_AND_HUMIDITY\"},\"inputActivation\":\"VCC\"}");
 
   EXPECT_EQ(cfg.get_available_fields(),
             SUPLA_DEVICE_CONFIG_FIELD_STATUS_LED |
@@ -695,7 +923,8 @@ TEST_F(DeviceConfigTest, availableFields) {
                 SUPLA_DEVICE_CONFIG_FIELD_DISABLE_USER_INTERFACE |
                 SUPLA_DEVICE_CONFIG_FIELD_AUTOMATIC_TIME_SYNC |
                 SUPLA_DEVICE_CONFIG_FIELD_HOME_SCREEN_OFF_DELAY |
-                SUPLA_DEVICE_CONFIG_FIELD_HOME_SCREEN_CONTENT);
+                SUPLA_DEVICE_CONFIG_FIELD_HOME_SCREEN_CONTENT |
+                SUPLA_DEVICE_CONFIG_FIELD_INPUT_ACTIVATION);
 }
 
 TEST_F(DeviceConfigTest, modbus_1) {


### PR DESCRIPTION
  Adds device-level InputActivation configuration with GND and VCC modes.

  - Adds protocol field bit 12 and an 8-byte configuration structure (bit 11 is left for ThermalProtection).
  - Stores selected mode in user JSON.
  - Stores supported modes in device properties.
  - Adds validation, serialization, merge and removal handling.