### PR TITLE
Proto: add extended weekly schedule proposal

### DIFF
--- a/supla-common/proto.h
+++ b/supla-common/proto.h
@@ -690,6 +690,8 @@ extern char sproto_tag[SUPLA_TAG_SIZE];
   0x400000000  // ver. >= 28
 #define SUPLA_CHANNEL_FLAG_RELAY_MODE_AUTOMATIC_SUPPORTED \
   0x800000000  // ver. >= 28
+#define SUPLA_CHANNEL_FLAG_EXTENDED_WEEKLY_SCHEDULE \
+  0x1000000000ULL  // ver. >= 29
 #pragma pack(push, 1)
 
 typedef struct {
@@ -2879,6 +2881,7 @@ typedef struct {
 #define SUPLA_CONFIG_TYPE_ALT_WEEKLY_SCHEDULE 3
 #define SUPLA_CONFIG_TYPE_OCR 4
 #define SUPLA_CONFIG_TYPE_EXTENDED 5
+#define SUPLA_CONFIG_TYPE_EXTENDED_WEEKLY_SCHEDULE 6
 
 /********************************************
  * DEVICE CONFIG STRUCTURES
@@ -3264,6 +3267,33 @@ typedef struct {
   // Days of week are numbered: 0 - Sunday, 1 - Monday, etc.
   unsigned char Quarters[SUPLA_WEEKLY_SCHEDULE_VALUES_SIZE / 2];  // 336 B
 } TChannelConfig_WeeklySchedule;                                  // v. >= 21
+
+#define SUPLA_EXTENDED_WEEKLY_SCHEDULE_MODEL_UNSPECIFIED 0
+// The channel supports switching between manual and weekly schedule modes,
+// but weekly schedule configuration is not available through SUPLA.
+// PayloadVersion and PayloadSize have to be 0 for this model.
+#define SUPLA_EXTENDED_WEEKLY_SCHEDULE_MODEL_MODE_ONLY 1
+#define SUPLA_EXTENDED_WEEKLY_SCHEDULE_MODEL_PROVENT 2
+
+#define SUPLA_EXTENDED_WEEKLY_SCHEDULE_ENVELOPE_VERSION 1
+#define SUPLA_EXTENDED_WEEKLY_SCHEDULE_HEADER_SIZE 16
+#define SUPLA_EXTENDED_WEEKLY_SCHEDULE_PAYLOAD_MAXSIZE \
+  (SUPLA_CHANNEL_CONFIG_MAXSIZE - SUPLA_EXTENDED_WEEKLY_SCHEDULE_HEADER_SIZE)
+
+// ConfigSize has to equal HeaderSize + PayloadSize. HeaderSize has to be at
+// least SUPLA_EXTENDED_WEEKLY_SCHEDULE_HEADER_SIZE and cannot exceed
+// ConfigSize.
+typedef struct {
+  unsigned char Version;  // SUPLA_EXTENDED_WEEKLY_SCHEDULE_ENVELOPE_VERSION
+  unsigned char HeaderSize;
+  unsigned _supla_int16_t Model;  // SUPLA_EXTENDED_WEEKLY_SCHEDULE_MODEL_
+  unsigned _supla_int16_t PayloadVersion;
+  unsigned _supla_int16_t PayloadSize;
+  unsigned char Reserved[8];  // Set to 0 when sending; ignore when receiving.
+  // For HeaderSize greater than SUPLA_EXTENDED_WEEKLY_SCHEDULE_HEADER_SIZE,
+  // payload starts at ((unsigned char *)config) + HeaderSize.
+  unsigned char Payload[SUPLA_EXTENDED_WEEKLY_SCHEDULE_PAYLOAD_MAXSIZE];
+} TChannelConfig_ExtendedWeeklySchedule;  // v. >= 29
 
 // Config used for thermometers, humidity sensors, and thermometers with
 // humidity channels.

--- a/supla-common/proto.h
+++ b/supla-common/proto.h
@@ -684,14 +684,14 @@ extern char sproto_tag[SUPLA_TAG_SIZE];
 #define SUPLA_CHANNEL_FLAG_HAS_PARENT 0x20000000                  // ver. >= 21
 #define SUPLA_CHANNEL_FLAG_CALCFG_RESTART_SUBDEVICE 0x40000000    // ver. >= 25
 #define SUPLA_CHANNEL_FLAG_BATTERY_COVER_AVAILABLE 0x80000000     // ver. >= 25
-#define SUPLA_CHANNEL_FLAG_BUTTON_MODE_SUPPORTED 0x100000000      // ver. >= 28
-#define SUPLA_CHANNEL_FLAG_RELAY_MODE_ONCE_SUPPORTED 0x200000000  // ver. >= 28
+#define SUPLA_CHANNEL_FLAG_BUTTON_MODE_SUPPORTED 0x100000000      // ver. >= 29
+#define SUPLA_CHANNEL_FLAG_RELAY_MODE_START_SUPPORTED 0x200000000  // ver. >= 29
 #define SUPLA_CHANNEL_FLAG_RELAY_MODE_FORCED_SUPPORTED \
-  0x400000000  // ver. >= 28
+  0x400000000  // ver. >= 29
 #define SUPLA_CHANNEL_FLAG_RELAY_MODE_AUTOMATIC_SUPPORTED \
-  0x800000000  // ver. >= 28
-#define SUPLA_CHANNEL_FLAG_EXTENDED_WEEKLY_SCHEDULE \
-  0x1000000000ULL  // ver. >= 29
+  0x800000000  // ver. >= 29
+#define SUPLA_CHANNEL_FLAG_RELAY_MODE_NOT_SET_SUPPORTED \
+  0x1000000000  // ver. >= 29; weekly schedule no-op program
 #pragma pack(push, 1)
 
 typedef struct {
@@ -2428,8 +2428,9 @@ typedef struct {
 
 // Relay modes and commands
 #define SUPLA_RELAY_MODE_NOT_SET 0
-#define SUPLA_RELAY_MODE_ON_ONCE 1
-#define SUPLA_RELAY_MODE_OFF_ONCE 2
+// Initial state on entering a program block (not a continuously forced state).
+#define SUPLA_RELAY_MODE_START_ON 1
+#define SUPLA_RELAY_MODE_START_OFF 2
 #define SUPLA_RELAY_MODE_FORCED_ON 3
 #define SUPLA_RELAY_MODE_FORCED_OFF 4
 #define SUPLA_RELAY_MODE_AUTOMATIC 5
@@ -2443,7 +2444,7 @@ typedef struct {
 typedef struct {
   char hi;  // actual state of relay  - 0 turned off, >= 1 - turned on
   unsigned _supla_int16_t flags;  // SUPLA_RELAY_FLAG_*
-  unsigned char RelayMode;        // see SUPLA_RELAY_MODE_, v. >= 28,
+  unsigned char RelayMode;        // see SUPLA_RELAY_MODE_, v. >= 29,
                                   // only if channel Flags:
                                   // SUPLA_CHANNEL_FLAG_RELAY_MODE_* are set.
 } TRelayChannel_Value;            // v. >= 15
@@ -3243,10 +3244,16 @@ typedef struct {
   union {
     _supla_int16_t SetpointTemperatureHeat;  // * 0.01 - used for heating
     _supla_int16_t Value1;
+    // Relay: duration of the state selected by START_ON/START_OFF, in seconds.
+    // Zero in both duration fields preserves the untimed program behavior.
+    unsigned _supla_int16_t RelayModeDurationS;
   };
   union {
     _supla_int16_t SetpointTemperatureCool;  // * 0.01 - used for cooling
     _supla_int16_t Value2;
+    // Relay: opposite-state duration, in seconds. Nonzero enables repetition
+    // and requires RelayModeDurationS > 0. Other modes require both times zero.
+    unsigned _supla_int16_t RelayOppositeModeDurationS;
   };
 } TWeeklyScheduleProgram;
 

--- a/supla-common/proto_check.cpp
+++ b/supla-common/proto_check.cpp
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#include <cstddef>
+
 #include "proto.h"
 
 static_assert(sizeof(_supla_int16_t) == 2);
@@ -269,6 +271,11 @@ static_assert(sizeof(TChannelConfig_HVAC) <= SUPLA_CHANNEL_CONFIG_MAXSIZE);
 static_assert(sizeof(TChannelConfig_WeeklySchedule) == 356);
 static_assert(sizeof(TChannelConfig_WeeklySchedule) <=
               SUPLA_CHANNEL_CONFIG_MAXSIZE);
+static_assert(sizeof(TChannelConfig_ExtendedWeeklySchedule) ==
+              SUPLA_CHANNEL_CONFIG_MAXSIZE);
+static_assert(offsetof(TChannelConfig_ExtendedWeeklySchedule, Payload) ==
+              SUPLA_EXTENDED_WEEKLY_SCHEDULE_HEADER_SIZE);
+static_assert(SUPLA_EXTENDED_WEEKLY_SCHEDULE_PAYLOAD_MAXSIZE == 496);
 static_assert((unsigned int)544 == sizeof(TSC_DeviceConfigUpdateOrResult));
 static_assert((unsigned int)20 == sizeof(TCS_GetDeviceConfigRequest));
 static_assert((unsigned int)9 == sizeof(TCS_GetChannelConfigRequest));

--- a/supla-common/test/ProtoTest.cpp
+++ b/supla-common/test/ProtoTest.cpp
@@ -3,6 +3,9 @@
 
 #include "ProtoTest.h"
 
+#include <cstddef>
+#include <cstdio>
+
 #include "gtest/gtest.h"  // NOLINT
 #include "proto.h"
 
@@ -284,6 +287,12 @@ TEST_F(ProtoTest, check_size_of_structures_and_types) {
   EXPECT_EQ(sizeof(TChannelConfig_WeeklySchedule), 356);
   EXPECT_LE(sizeof(TChannelConfig_WeeklySchedule),
             static_cast<size_t>(SUPLA_CHANNEL_CONFIG_MAXSIZE));
+
+  EXPECT_EQ(sizeof(TChannelConfig_ExtendedWeeklySchedule),
+            static_cast<size_t>(SUPLA_CHANNEL_CONFIG_MAXSIZE));
+  EXPECT_EQ(offsetof(TChannelConfig_ExtendedWeeklySchedule, Payload),
+            static_cast<size_t>(SUPLA_EXTENDED_WEEKLY_SCHEDULE_HEADER_SIZE));
+  EXPECT_EQ(SUPLA_EXTENDED_WEEKLY_SCHEDULE_PAYLOAD_MAXSIZE, 496);
 
   EXPECT_EQ((unsigned int)544, sizeof(TSC_DeviceConfigUpdateOrResult));
   EXPECT_EQ((unsigned int)20, sizeof(TCS_GetDeviceConfigRequest));


### PR DESCRIPTION
Proposal for extended weekly schedule configs. New channel flag is used to indicate support for extended weekly schedule channel config.
This config may handle other types of weekly schedule configuration than native SUPLA format (with 15 min window).

Currently there are two types added:
 - MODE_ONLY - it means that schedule config is unknown to SUPLA, but we can tell external device to enable/disable schedule mode.
 - Provent - placeholder for Provent schedule type. Exact binary format of payload will be specified later.
