### PR TITLE
supla-common: compilation fix for AVR builds. Remove eh.h dependency …

### DIFF
--- a/supla-common/proto_check.cpp
+++ b/supla-common/proto_check.cpp
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: AC SOFTWARE SP. Z O.O.
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-#include <cstddef>
+#include <stddef.h>
 
 #include "proto.h"
 

--- a/supla-common/srpc.c
+++ b/supla-common/srpc.c
@@ -6,15 +6,23 @@
 #include <stdlib.h>
 #include <string.h>
 
+#if !defined(__AVR__) && !defined(_WIN32)
+#include <sys/time.h>
+#endif
+
 #include "lck.h"
 #include "log.h"
 #include "proto.h"
 
-// ESP8266 and ESP32
-#if defined(ESP8266) || defined(ESP32)
+#if defined(SUPLA_DEVICE) || defined(ARDUINO) || defined(ESP8266) || \
+    defined(ESP32)
 #ifndef __EH_DISABLED
 #define __EH_DISABLED
-#endif /*__EH_DISABLED*/
+#endif  /* __EH_DISABLED */
+#endif
+
+// ESP8266 and ESP32
+#if defined(ESP8266) || defined(ESP32)
 #define SRPC_BUFFER_SIZE 256
 #define SRPC_QUEUE_SIZE 2
 #define SRPC_QUEUE_MIN_ALLOC_COUNT 2
@@ -45,7 +53,6 @@
 // Linux target, other?
 #elif defined(SUPLA_DEVICE)
 #define SRPC_BUFFER_SIZE 1024
-#define __EH_DISABLED
 
 // other not releated to supla-device
 #else

--- a/supla-common/srpc.h
+++ b/supla-common/srpc.h
@@ -7,7 +7,9 @@
 #include <stddef.h>
 #include <stdio.h>
 
+#if !defined(SUPLA_DEVICE) && !defined(ARDUINO)
 #include "eh.h"
+#endif
 #include "proto.h"
 #if defined(ESP32)
 #include <esp8266-compat.h>
@@ -105,7 +107,9 @@ typedef struct {
 #endif
   _func_srpc_event_OnMinVersionRequired on_min_version_required;
 
+#if !defined(SUPLA_DEVICE) && !defined(ARDUINO)
   TEventHandler *eh;
+#endif
 
   void *user_params;
 } TsrpcParams;


### PR DESCRIPTION
…from srpc when targed doesn't use it.
